### PR TITLE
test: include opencode mapping in suite

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -114,6 +114,7 @@ test_command_flags() {
         "droid:--skip-permissions-unsafe"
         "amp:--dangerously-allow-all"
         "cursor-agent:--force"
+        "opencode:"  # no extra flags
         "unknown-tool:--yolo"
     )
 


### PR DESCRIPTION
This follow-up ports a small test improvement from runner-up PRs: include opencode in the mapping checks (no additional flags). This aligns tests with the standardized agent list (codex, claude, copilot, droid, amp, cursor-agent, opencode, default).