### PR TITLE
docs: add OpenCode examples + quick cleanup snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ yolo codex --help
 yolo -w claude
 yolo --worktree codex "experimental refactoring"
 
+# OpenCode (no extra flags added)
+yolo opencode "build"
+yolo -w opencode "run integration suite"
+
 # Help and version
 yolo --help
 yolo --version
@@ -123,6 +127,10 @@ yolo --version
 # Dry-run mode
 yolo --dry-run claude "test changes"
 yolo -n codex  # Short form
+
+# Quick cleanup (from repository root)
+git worktree remove .conductor/<agent>-<YYYYMMDD-HHMMSS>
+git branch -D yolo/<agent>/<YYYYMMDD-HHMMSS>
 ```
 
 ## How It Works


### PR DESCRIPTION
This PR adds:

- Explicit examples for the  agent (no extra flags), including a worktree invocation.
- A brief, copy‑pasteable cleanup snippet (worktree removal + branch delete) near the Examples section.

This complements the existing Supported Commands table and detailed cleanup section further down by surfacing quick usage + cleanup steps where users look first.