### PR TITLE
Add full YOLO mode with random agent selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Part of the **AI-Aligned** toolchain:
 
 - 🚀 **Quick Launch**: Simple wrapper to launch AI tools with one command
 - 🎯 **Smart Flags**: Automatically adds appropriate bypass flags for each AI tool
+- 🎲 **Full YOLO Mode**: Run without arguments to randomly select an installed agent
 - 🌳 **Worktree Isolation**: Optional `-w` flag creates isolated git worktrees
 - 🔒 **Safe Experimentation**: Work in isolated environments without affecting main codebase
 - 🧹 **Clean History**: Separate branches for each agent session with timestamps
@@ -56,6 +57,23 @@ source ~/.bashrc  # or ~/.zshrc, ~/.config/fish/config.fish, etc.
 ```
 
 ## Usage
+
+### Full YOLO Mode
+
+Can't decide which AI assistant to use? Let YOLO decide for you!
+
+```bash
+# Randomly select from all installed coding agents
+yolo
+
+# Full YOLO in a new worktree
+yolo -w
+
+# See what would happen without actually running
+yolo --dry-run
+```
+
+When you run `yolo` without specifying a command, it scans your system for all installed supported coding agents (codex, claude, copilot, droid, amp, cursor-agent, opencode) and picks one at random. You only live yolo - even choosing your AI assistant is too much commitment!
 
 ### Basic Usage
 
@@ -107,6 +125,10 @@ yolo -w claude "refactor the entire codebase"
 ### Examples
 
 ```bash
+# Full YOLO mode - random agent selection
+yolo
+yolo -w  # Random agent in a new worktree
+
 # Basic usage
 yolo claude
 yolo claude "fix all the bugs"
@@ -125,6 +147,7 @@ yolo --help
 yolo --version
 
 # Dry-run mode
+yolo --dry-run  # See which agent would be selected
 yolo --dry-run claude "test changes"
 yolo -n codex  # Short form
 
@@ -134,6 +157,26 @@ git branch -D yolo/<agent>/<YYYYMMDD-HHMMSS>
 ```
 
 ## How It Works
+
+### Full YOLO Mode
+
+When you run `yolo` without specifying a command:
+
+```bash
+# You type:
+yolo
+
+# YOLO does:
+# 1. Scans PATH for installed agents (codex, claude, copilot, droid, amp, cursor-agent, opencode)
+# 2. Picks one at random using $RANDOM
+# 3. Adds appropriate flags for that agent
+# 4. Launches it
+
+# Example output:
+# Full YOLO mode activated! Picking a random coding agent...
+# Selected: claude
+# [claude launches with --dangerously-skip-permissions]
+```
 
 ### Flag Mapping
 

--- a/executable_yolo
+++ b/executable_yolo
@@ -67,7 +67,7 @@ show_usage() {
     cat << EOF
 YOLO - AI CLI Tool Wrapper with Worktree Support
 
-Usage: yolo [OPTIONS] <command> [args...]
+Usage: yolo [OPTIONS] [command] [args...]
 
 Options:
   -w, --worktree    Create a git worktree in .conductor/ before running command
@@ -85,8 +85,14 @@ Supported Commands:
   opencode          No extra flags added
   <other>           Adds --yolo (generic fallback)
 
+Full YOLO Mode:
+  Run 'yolo' without a command to randomly select an installed coding agent.
+  You only live yolo - let fate decide which AI assistant you get!
+
 Examples:
+  yolo                           # Full YOLO mode - random agent selection
   yolo claude                    # Run claude with --dangerously-skip-permissions
+  yolo -w                        # Full YOLO mode in a new worktree
   yolo -w claude "fix the bug"   # Create worktree, then run claude
   yolo copilot chat              # Run copilot chat with safety flags disabled
 
@@ -212,6 +218,36 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Get all installed supported coding agents
+get_installed_agents() {
+    local agents=()
+    local supported_commands=("codex" "claude" "copilot" "droid" "amp" "cursor-agent" "opencode")
+
+    for cmd in "${supported_commands[@]}"; do
+        if command_exists "$cmd"; then
+            agents+=("$cmd")
+        fi
+    done
+
+    printf "%s\n" "${agents[@]}"
+}
+
+# Pick a random agent from installed agents
+pick_random_agent() {
+    local agents
+    mapfile -t agents < <(get_installed_agents)
+
+    if [[ ${#agents[@]} -eq 0 ]]; then
+        print_error "no supported coding agents found in PATH"
+        print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode"
+        return 1
+    fi
+
+    # Use RANDOM to pick a random index
+    local random_index=$((RANDOM % ${#agents[@]}))
+    echo "${agents[$random_index]}"
+}
+
 # Main function
 main() {
     local use_worktree=false
@@ -257,12 +293,12 @@ main() {
         esac
     done
 
-    # Check if command was provided
+    # If no command was provided, pick a random one (full yolo mode!)
     if [[ -z "$command_name" ]]; then
-        print_error "missing command argument"
-        echo ""
-        show_usage
-        exit 1
+        print_info "Full YOLO mode activated! Picking a random coding agent..."
+        command_name="$(pick_random_agent)" || exit 1
+        print_success "Selected: $command_name"
+        print_info ""
     fi
 
     # Check if command exists


### PR DESCRIPTION
## Summary

- Adds "full YOLO mode" that randomly selects an installed coding agent when `yolo` is run without arguments
- Implements `get_installed_agents()` to scan PATH for supported agents
- Implements `pick_random_agent()` to randomly select from installed agents using `$RANDOM`
- Updates help text and README with full documentation of the new feature
- Works with `-w` flag for worktree mode and `--dry-run` for previewing selection

## Test plan

- [ ] Run `yolo` without arguments to verify random agent selection works
- [ ] Run `yolo --dry-run` to verify it shows which agent would be selected
- [ ] Run `yolo -w` to verify random agent selection works with worktree mode
- [ ] Verify help text displays correctly with `yolo --help`
- [ ] Test with different combinations of installed agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)