### PR TITLE
Add -a/--all-agents option for multi-agent mode

### DIFF
--- a/executable_yolo
+++ b/executable_yolo
@@ -84,6 +84,8 @@ Options:
   -c, --clean       Automatically clean up worktree after command completes
   -nc, --no-clean   Preserve worktree after command completes (no prompt)
   -e, --editor      Launch \$EDITOR to compose prompt (works in all modes)
+  -a, --all-agents, --waddan
+                    Launch multi-agent mode with all supported agents found on system
   -n, --dry-run     Show what would be executed without running it
   -m, --mop         Clean up all YOLO worktrees, branches, and processes
   -h, --help        Show this help message
@@ -115,6 +117,9 @@ Full YOLO Mode:
 Examples:
   yolo                             # Full YOLO mode - random agent selection
   yolo -w                          # Full YOLO mode in a new worktree
+  yolo -a "implement feature X"    # Launch all available agents in parallel
+  yolo --waddan "build tests"      # Same as -a (alternative name)
+  yolo -e -a                       # Compose prompt in editor, run all agents
   yolo -e claude                   # Compose prompt in editor, run claude
   yolo claude                      # Run claude with --dangerously-skip-permissions
   yolo -w claude "fix the bug"     # Create worktree, then run claude (prompt for cleanup)
@@ -1255,6 +1260,7 @@ main() {
     local dry_run=false
     local auto_clean=""
     local use_editor=false
+    local use_waddan=false
     local command_name=""
     local command_args=()
 
@@ -1283,6 +1289,10 @@ main() {
                 ;;
             -e|--editor)
                 use_editor=true
+                shift
+                ;;
+            -a|--all-agents|--waddan)
+                use_waddan=true
                 shift
                 ;;
             -n|--dry-run)
@@ -1320,6 +1330,39 @@ main() {
                 ;;
         esac
     done
+
+    # Handle -a/--all-agents/--waddan mode: launch all available agents
+    if [[ "$use_waddan" == "true" ]]; then
+        print_info "All-agents mode activated! Launching all available agents..."
+        local -a all_agents
+        local agent
+        while IFS= read -r agent; do
+            all_agents+=("$agent")
+        done < <(get_installed_agents)
+        
+        if [[ ${#all_agents[@]} -eq 0 ]]; then
+            print_error "no supported coding agents found in PATH"
+            print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini"
+            exit 1
+        fi
+        
+        # Join agents with commas
+        local agent_csv
+        agent_csv=$(IFS=','; echo "${all_agents[*]}")
+        print_success "Found ${#all_agents[@]} agents: $agent_csv"
+        
+        # Collect remaining arguments as prompt if provided
+        local -a waddan_args=()
+        if [[ -n "$command_name" ]]; then
+            waddan_args=("$command_name")
+            if (( ${#command_args[@]} > 0 )); then
+                waddan_args+=("${command_args[@]}")
+            fi
+        fi
+        
+        run_multi_agents "$agent_csv" "$dry_run" "$auto_clean" "${waddan_args[@]+"${waddan_args[@]}"}"
+        exit $?
+    fi
 
     # If no command was provided, pick a random one (full yolo mode!)
     if [[ -z "$command_name" ]]; then


### PR DESCRIPTION
Adds a new `-a`/`--all-agents` flag that automatically launches all installed agents in multi-agent mode.

## Features
- Discovers all installed agents automatically (codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini)
- Creates individual worktrees for each agent
- Launches them in parallel using ghostty/zellij/tmux
- Works seamlessly with existing options:
  - `-e` for editor-based prompts
  - `-n` for dry-run testing
  - `-c`/`-nc` for cleanup control

## Examples
```bash
yolo -a "build the app"          # Run all installed agents in parallel
yolo -a -e                       # Compose prompt in editor, run all agents
yolo -a -n "test prompt"         # Dry-run to see what would be executed
```

This makes it easy to run all available agents without manually listing them.