### PR TITLE
feat: implement proper Ghostty split method for copilot and kimi

### DIFF
--- a/executable_yolo
+++ b/executable_yolo
@@ -1494,7 +1494,8 @@ main() {
 
                 # Use Ghostty split method if available for cleaner interactive experience
                 if is_ghostty; then
-                    local agent_cmd="copilot $flags_str --add-dir $(printf %q \"$trust_dir\")"
+                    local agent_cmd
+                    agent_cmd="copilot $flags_str --add-dir $(printf %q \"$trust_dir\")"
                     run_single_agent_ghostty_with_prompt "$agent_cmd" "$prompt_joined" "true"
                     exit $?
                 else
@@ -1523,7 +1524,8 @@ main() {
                 # kimi --command exits after execution, not interactive
                 # Use Ghostty split method for proper interactive experience
                 if is_ghostty; then
-                    local agent_cmd="kimi $flags_str"
+                    local agent_cmd
+                    agent_cmd="kimi $flags_str"
                     run_single_agent_ghostty_with_prompt "$agent_cmd" "$prompt_joined"
                     exit $?
                 else


### PR DESCRIPTION
## Summary

- Implemented proper Ghostty terminal split method for agents that don't support interactive prompts
- Added new `run_single_agent_ghostty_with_prompt()` function
- Modified copilot to use Ghostty split + AppleScript instead of one-shot + continue hack
- Added kimi as a supported agent with proper Ghostty split handling

## Problem

Some agents, namely copilot and kimi, don't support launching interactively with a provided prompt:
- copilot: Previously used a one-shot + continue workaround
- kimi: Would simply exit when launched with a prompt

## Solution

The proper approach is:
1. Split the Ghostty terminal
2. Focus the new split
3. Launch the agent (without prompt)
4. Enter the prompt via AppleScript
5. Send return via AppleScript

### Implementation Details

**New Function**: `run_single_agent_ghostty_with_prompt()`
- Splits terminal using Ghostty's "Split Right" menu item
- Launches agent using `send_ghostty_command()`
- Waits 2 seconds for agent startup
- Sends prompt via `send_ghostty_command()`

**copilot Changes**:
- When in Ghostty + has prompt: uses new split method
- Fallback: keeps one-shot + continue for non-Ghostty terminals
- Maintains `--add-dir` flag for directory trust

**kimi Support**:
- Added to supported agents list
- Single-agent mode: requires Ghostty, shows error otherwise
- Multi-agent mode: launches interactively (manual prompt entry)
- Added to documentation

## Benefits

✅ Cleaner interactive experience in Ghostty
✅ Agents receive prompts in their native interactive mode  
✅ No more workarounds or hacks
✅ Easy to extend to other agents with similar issues
✅ Maintains backward compatibility (copilot fallback)

## Test Plan

- [x] Bash syntax validation passes
- [ ] Test copilot in Ghostty with prompt
- [ ] Test copilot in non-Ghostty terminal with prompt (fallback)
- [ ] Test copilot without prompt
- [ ] Test kimi in Ghostty with prompt
- [ ] Test kimi error message in non-Ghostty terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)