### PR TITLE
feat: make cleanup default for worktree sessions (Y/n)

### DIFF
--- a/executable_yolo
+++ b/executable_yolo
@@ -1173,17 +1173,17 @@ prompt_cleanup() {
 
     echo ""
     print_info "Worktree session completed."
-    read -r -p "Clean up worktree and branch? (y/n): " response
+    read -r -p "Clean up worktree and branch? (Y/n): " response
 
     case "$response" in
-        [yY]|[yY][eE][sS])
-            cleanup_worktree "$branch_name" "$worktree_path" "$repo_root"
-            ;;
-        *)
+        [nN]|[nN][oO])
             print_info "Worktree preserved at: $worktree_path"
             print_info "To clean up later, run:"
             echo "  git worktree remove $worktree_path"
             echo "  git branch -D $branch_name"
+            ;;
+        *)
+            cleanup_worktree "$branch_name" "$worktree_path" "$repo_root"
             ;;
     esac
 }


### PR DESCRIPTION
## Summary
- Changed cleanup prompt from `(y/n)` to `(Y/n)` to make cleanup the default
- Updated logic so only 'n' or 'no' responses skip cleanup
- Any other response (including pressing Enter) now triggers cleanup

## Motivation
Making cleanup the default provides a safer behavior for temporary worktrees created with `yolo -w`. Users are less likely to leave orphaned worktrees behind if cleanup happens by default.

## Changes
- Modified `prompt_cleanup()` function in `executable_yolo:1176`
- Inverted the case statement logic to treat 'n'/'no' as the special case
- Default behavior (wildcard case) now performs cleanup

## Test plan
- [x] Syntax check with `bash -n` passes
- [ ] Manual test: Run `yolo -w <command>` and verify pressing Enter triggers cleanup
- [ ] Manual test: Run `yolo -w <command>` and verify typing 'n' preserves worktree
- [ ] Manual test: Run `yolo -w <command>` and verify typing 'y' triggers cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)