### PR TITLE
Add Grok Build (xAI) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Use `--mop` to clean up orphaned worktrees from interrupted sessions or when you
 | `kimi` | `--yolo` (+ `--command` when prompt present) |
 | `crush` | `--yolo` (+ Ghostty injection when prompt present) |
 | `goose` | *(no flags - prompts passed via stdin)* |
+| `grok` | `--yolo` (Grok Build by xAI) |
 | *(other)* | `--yolo` |
 
 ### Examples

--- a/executable_yolo
+++ b/executable_yolo
@@ -23,6 +23,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Single source of truth for supported AI coding agents.
+# This list must be kept in sync with the case arms in get_default_flags().
+SUPPORTED_AGENTS=("codex" "claude" "copilot" "droid" "amp" "cursor-agent" "opencode" "qwen" "gemini" "kimi" "crush" "aider" "goose" "auggie" "grok")
+
 # Enable colored output if stdout is a terminal
 if [[ -t 1 ]]; then
     USE_COLOR=true
@@ -330,9 +334,8 @@ command_exists() {
 # Get all installed supported coding agents
 get_installed_agents() {
     local agents=()
-    local supported_commands=("codex" "claude" "copilot" "droid" "amp" "cursor-agent" "opencode" "qwen" "gemini" "kimi" "crush" "aider" "goose" "auggie" "grok")
 
-    for cmd in "${supported_commands[@]}"; do
+    for cmd in "${SUPPORTED_AGENTS[@]}"; do
         if command_exists "$cmd"; then
             agents+=("$cmd")
         fi
@@ -1203,7 +1206,8 @@ pick_random_agent() {
 
     if [[ ${#agents[@]} -eq 0 ]]; then
         print_error "no supported coding agents found in PATH"
-        print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie, grok"
+        local IFS=', '
+        print_info "Supported agents: ${SUPPORTED_AGENTS[*]}"
         return 1
     fi
 
@@ -1494,7 +1498,8 @@ main() {
         
         if [[ ${#all_agents[@]} -eq 0 ]]; then
             print_error "no supported coding agents found in PATH"
-            print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie, grok"
+            local IFS=', '
+            print_info "Supported agents: ${SUPPORTED_AGENTS[*]}"
             exit 1
         fi
         

--- a/executable_yolo
+++ b/executable_yolo
@@ -317,7 +317,10 @@ get_command_flags() {
             echo "--allow-indexing"
             ;;
         grok)
-            # Grok Build (xAI) supports --yolo for auto-approve all tool calls
+            # Grok Build (xAI) — use --yolo for full auto-approval.
+            # This is the documented CLI flag (see ~/.grok/docs/user-guide/13-headless-mode.md
+            # and 14-agent-mode.md). The underlying config key is permission_mode=always-approve,
+            # but the user-facing flag exposed by the grok binary is --yolo.
             echo "--yolo"
             ;;
         *)

--- a/executable_yolo
+++ b/executable_yolo
@@ -106,6 +106,7 @@ Supported Commands:
   aider             Uses --yes-always (requires Ghostty for interactive prompts)
   goose             No extra flags added (prompts passed via stdin)
   auggie            Uses --allow-indexing; adds --print when prompt present
+  grok              Uses --yolo (Grok Build by xAI)
   <other>           Adds --yolo (generic fallback)
 
 Multi-agent Mode:
@@ -311,6 +312,10 @@ get_command_flags() {
             # Auggie uses --allow-indexing to skip indexing confirmation
             echo "--allow-indexing"
             ;;
+        grok)
+            # Grok Build (xAI) supports --yolo for auto-approve all tool calls
+            echo "--yolo"
+            ;;
         *)
             echo "--yolo"
             ;;
@@ -325,7 +330,7 @@ command_exists() {
 # Get all installed supported coding agents
 get_installed_agents() {
     local agents=()
-    local supported_commands=("codex" "claude" "copilot" "droid" "amp" "cursor-agent" "opencode" "qwen" "gemini" "kimi" "crush" "aider" "goose" "auggie")
+    local supported_commands=("codex" "claude" "copilot" "droid" "amp" "cursor-agent" "opencode" "qwen" "gemini" "kimi" "crush" "aider" "goose" "auggie" "grok")
 
     for cmd in "${supported_commands[@]}"; do
         if command_exists "$cmd"; then
@@ -1198,7 +1203,7 @@ pick_random_agent() {
 
     if [[ ${#agents[@]} -eq 0 ]]; then
         print_error "no supported coding agents found in PATH"
-        print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie"
+        print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie, grok"
         return 1
     fi
 
@@ -1489,7 +1494,7 @@ main() {
         
         if [[ ${#all_agents[@]} -eq 0 ]]; then
             print_error "no supported coding agents found in PATH"
-            print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie"
+            print_info "Supported agents: codex, claude, copilot, droid, amp, cursor-agent, opencode, gemini, kimi, crush, aider, goose, auggie, grok"
             exit 1
         fi
         


### PR DESCRIPTION
Adds support for the `grok` command (Grok Build by xAI) to the YOLO multi-agent launcher.

- `yolo grok "your prompt"` now works
- Uses `--yolo` flag (native to Grok Build for auto-approving tools)
- Grok is now discovered in full YOLO mode and multi-agent mode (`-a` / `--waddan`)
- Updated all internal lists and the README table

Dogfooded: This commit was made inside Grok Build using the patched ai-aligned-git wrapper.

Part of expanding the AI Ecoverse toolchain to support Grok Build across all tools.