### PR TITLE
fix(yolo): correct description for `pi` in README and executable_yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Use `--mop` to clean up orphaned worktrees from interrupted sessions or when you
 | `crush` | `--yolo` (+ Ghostty injection when prompt present) |
 | `goose` | *(no flags - prompts passed via stdin)* |
 | `grok` | `--yolo` (Grok Build by xAI) |
-| `pi` | *(no flags - runs interactively by default, user blesses tool calls; has --print for non-interactive single-shot but no auto-approve flag; runs as-is)* |
+| `pi` | *(no flags — pi is YOLO by default; auto-approves all tool calls with no permission prompts, matching yolo's intent natively)* |
 | *(other)* | `--yolo` |
 
 ### Examples

--- a/executable_yolo
+++ b/executable_yolo
@@ -114,7 +114,7 @@ Supported Commands:
   goose             No extra flags added (prompts passed via stdin)
   auggie            Uses --allow-indexing; adds --print when prompt present
   grok              Uses --yolo (Grok Build by xAI)
-  pi                No extra flags (runs as-is; interactive by default, user blesses tool calls; --print for non-interactive single-shot)
+  pi                No extra flags (pi is YOLO by default; auto-approves all tool calls with no permission prompts, matching yolo's intent natively)
   <other>           Adds --yolo (generic fallback)
 
 Multi-agent Mode:
@@ -336,11 +336,9 @@ get_command_flags() {
             echo "--yolo"
             ;;
         pi)
-            # Pi (the coding agent you're running on) has no --yolo-equivalent
-            # auto-approve flag. Pi runs interactively by default and the user
-            # has to bless tool calls. It has --print for non-interactive
-            # single-shot output, but no global yes-everything flag.
-            # Fall back to generic case: no extra flag — pi runs as-is.
+            # Pi is YOLO-by-default natively — no flag needed (auto-approves all
+            # tool calls with no permission prompts, matching yolo's intent).
+            # See https://github.com/earendil-works/pi/discussions/3169 (same as goose)
             echo ""
             ;;
         *)


### PR DESCRIPTION
The description we wrote for \`pi\` in PR #35 was inaccurate.

Pi is YOLO-by-default natively and auto-approves all tool calls with no
permission prompts (no flag needed — same as goose).

Source justifying the correction:
https://github.com/earendil-works/pi/discussions/3169

Changes in this PR:
* README.md: updated the agent-flag table row for \`pi\`
* executable_yolo: updated "Supported Commands" help text for \`pi\`
* executable_yolo: rewrote the comment block in \`get_command_flags()\` for the \`pi` case (only comments changed; `echo ` return preserved)

Commit authored as: Pi <pi@earendil.works>

Lars, please review.
EOF
)