### PR TITLE
feat(yolo): add native worktree support for droid

### DIFF
--- a/executable_yolo
+++ b/executable_yolo
@@ -85,8 +85,9 @@ Usage: yolo [OPTIONS] [command] [args...]
 
 Options:
   -w, --worktree    Create a git worktree in .yolo/ before running command
-                    (exceptions: 'claude' and 'grok' delegate to their built-in
-                    worktree support: claude uses .claude/worktrees/, grok uses its
+                    (exceptions: 'claude', 'grok', and 'droid' delegate to their
+                    built-in worktree support: claude uses .claude/worktrees/,
+                    grok uses its native -w/--worktree mode, droid uses its
                     native -w/--worktree mode)
   -c, --clean       Automatically clean up worktree after command completes
   -nc, --no-clean   Preserve worktree after command completes (no prompt)
@@ -145,22 +146,24 @@ Examples:
   yolo -w -c claude "experiment"   # Use claude's built-in --worktree (claude manages it)
   yolo -w -nc claude "keep this"   # Use claude's built-in --worktree (claude manages it)
   yolo -w grok "implement feature" # Use grok's native -w/--worktree (grok manages it)
+  yolo -w droid "implement feature" # Use droid's native -w/--worktree (droid manages it)
   yolo -e codex,claude,gemini      # Compose prompt in editor, run 3 agents in parallel
   yolo copilot chat                # Run copilot chat with safety flags disabled
   yolo aider "add auth"            # Run aider with auto-approval
   yolo -w aider "implement feature" # Create worktree, run aider with prompt
 
 Worktree Mode:
-  When using -w/--worktree flag (for commands other than claude or grok):
+  When using -w/--worktree flag (for commands other than claude, grok, or droid):
   - Creates .yolo/ directory in repository root
   - Creates branch: <command>-N (where N is the lowest available number)
   - Creates worktree: .yolo/<command>-N
   - Changes to worktree directory before running command
 
-  When using -w/--worktree flag with 'claude' or 'grok':
+  When using -w/--worktree flag with 'claude', 'grok', or 'droid':
   - Delegates worktree management to the tool's native support
     - claude: uses --worktree (managed under .claude/worktrees/)
     - grok: uses -w/--worktree (managed by grok's native worktree system)
+    - droid: uses -w/--worktree (managed by droid's native worktree system)
   - The tool handles worktree creation, naming, and cleanup
   - yolo's -c/--clean and -nc/--no-clean flags are ignored in this mode
 
@@ -1589,11 +1592,11 @@ main() {
     fi
 
     # Track whether yolo is managing the worktree itself
-    # claude and grok have built-in --worktree / -w support, so we delegate
-    # to them rather than creating our own worktree under .yolo/
+    # claude, grok, and droid have built-in --worktree / -w support, so we
+    # delegate to them rather than creating our own worktree under .yolo/
     local yolo_managed_worktree=false
     if [[ "$use_worktree" == "true" ]]; then
-        if [[ "$command_name" == "claude" || "$command_name" == "grok" ]]; then
+        if [[ "$command_name" == "claude" || "$command_name" == "grok" || "$command_name" == "droid" ]]; then
             print_info "Delegating worktree management to $command_name's built-in worktree support"
             # These tools handle their own worktree lifecycle, so yolo's -c/-nc
             # cleanup flags do not apply in this mode.
@@ -1700,6 +1703,15 @@ main() {
             fi
             ;;
         droid)
+            # droid has native -w/--worktree support; delegate to it when requested
+            if [[ "$use_worktree" == "true" ]]; then
+                full_command+=("-w")
+                # -w/--worktree takes an optional [name]; use -- to stop option
+                # parsing so the first prompt arg isn't consumed as the name.
+                if (( ${#command_args[@]} )); then
+                    full_command+=("--")
+                fi
+            fi
             # droid: pass prompt positionally; no special flags
             if (( ${#command_args[@]} )); then
                 full_command+=("${command_args[@]}")

--- a/test.sh
+++ b/test.sh
@@ -525,6 +525,89 @@ EOF
     rm -f "$claude_cmd"
 }
 
+# Test 10: Test yolo -w droid delegates to droid's built-in -w/--worktree
+test_droid_builtin_worktree() {
+    print_test_header "Test 10: Droid Built-in Worktree Delegation"
+
+    # Create a temporary git repository for testing
+    local test_repo="/tmp/yolo_test_droid_$$"
+    mkdir -p "$test_repo"
+    cd "$test_repo"
+
+    # Initialize git repo
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "test" > README.md
+    git add README.md
+    git commit -q -m "Initial commit"
+
+    # Create a dummy droid command that echoes args (so we can assert pass-through)
+    local droid_cmd="/tmp/droid"
+    cat > "$droid_cmd" << 'EOF'
+#!/bin/bash
+echo "Running in: $PWD"
+echo "Args: $@"
+EOF
+    chmod +x "$droid_cmd"
+
+    # Assertion 1: -w is passed through when -w is set
+    run_test
+    local output
+    if output=$(PATH="/tmp:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -w droid "fix the bug" 2>&1); then
+        if echo "$output" | grep -E -q -- "(^| )-w( |$)"; then
+            print_pass "yolo -w droid passes through -w flag"
+        else
+            print_fail "yolo -w droid should pass -w (got: $output)"
+        fi
+    else
+        print_fail "yolo -w droid failed to run"
+    fi
+
+    # Assertion 2: -- separator precedes the prompt so commander does not eat it
+    run_test
+    if echo "$output" | grep -F -q -- "-w -- fix the bug"; then
+        print_pass "yolo -w droid inserts -- before prompt to preserve it"
+    else
+        print_fail "yolo -w droid should insert -- before prompt (got: $output)"
+    fi
+
+    # Assertion 3: yolo did NOT create a .yolo/ directory
+    run_test
+    if [[ ! -d "$test_repo/.yolo" ]]; then
+        print_pass "yolo -w droid does not create .yolo/ worktree directory"
+    else
+        print_fail "yolo -w droid should not create .yolo/ directory"
+    fi
+
+    # Assertion 4: yolo did NOT create a git worktree
+    run_test
+    local wt_count
+    wt_count=$(git worktree list | wc -l | tr -d ' ')
+    if [[ "$wt_count" == "1" ]]; then
+        print_pass "yolo -w droid does not invoke git worktree add"
+    else
+        print_fail "yolo -w droid should not create a git worktree (found $wt_count)"
+    fi
+
+    # Assertion 5: yolo droid (without -w) does NOT pass -w
+    run_test
+    if output=$(PATH="/tmp:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" droid "hello" 2>&1); then
+        if ! echo "$output" | grep -E -q -- "(^|Args: .*) -w( |$)"; then
+            print_pass "yolo droid (no -w) does not pass -w"
+        else
+            print_fail "yolo droid should not pass -w without -w flag (got: $output)"
+        fi
+    else
+        print_fail "yolo droid failed to run"
+    fi
+
+    # Cleanup
+    cd /tmp
+    rm -rf "$test_repo"
+    rm -f "$droid_cmd"
+}
+
 # Print summary
 print_summary() {
     echo ""
@@ -567,6 +650,7 @@ main() {
     test_worktree_no_git_error
     test_argument_preservation
     test_claude_builtin_worktree
+    test_droid_builtin_worktree
 
     print_summary
 }


### PR DESCRIPTION
## Summary

Add native worktree delegation for `droid`, mirroring the existing behavior for `claude` and `grok`.

When using `yolo -w droid`, yolo now delegates worktree management to droid's built-in `-w/--worktree` flag instead of creating its own `.yolo/` worktree.

## Changes

- `executable_yolo`: route `droid` into the same delegation branch as `claude` and `grok` and append `-w --` (the `--` ensures the optional `[name]` doesn't swallow the prompt).
- `executable_yolo`: updated help text and examples.
- `test.sh`: added Test 10 (`test_droid_builtin_worktree`) mirroring the existing claude built-in worktree test:
  - `-w` passed through
  - `--` separator inserted before the prompt
  - no `.yolo/` directory created
  - no `git worktree add` invoked
  - without `-w`, `-w` is not passed to droid

## Verified

```
$ yolo -n -w droid "implement feature X"
Delegating worktree management to droid's built-in worktree support
Dry-run mode - would execute:
droid -w -- implement feature X

$ yolo -n droid "implement feature X"
Dry-run mode - would execute:
droid implement feature X
```