### PR TITLE
docs: cross-link gh-reaper for stale .yolo worktree cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Part of the **[AI Ecoverse](https://github.com/ai-ecoverse/.github)** - a compre
 - [gh-workflow-peek](https://github.com/ai-ecoverse/gh-workflow-peek) - Smarter GitHub Actions log filtering
 - [upskill](https://github.com/ai-ecoverse/gh-upskill) - Install Claude/Agent skills from other repositories
 - [as-a-bot](https://github.com/ai-ecoverse/as-a-bot) - GitHub App token broker for proper AI attribution
+- [gh-reaper](https://github.com/ai-ecoverse/gh-reaper) - Reap stale git worktrees by age and size (cleans up the `.yolo/` checkouts YOLO leaves behind)
 
 ## Features
 
@@ -208,6 +209,14 @@ yolo --mop  # or yolo -m
 ```
 
 Use `--mop` to clean up orphaned worktrees from interrupted sessions or when you want a fresh start.
+
+> **Tip:** `--mop` only tidies the *current* repo. To find and reap forgotten `.yolo/` worktrees across **every** repo on your machine — sorted by age and size, and safely skipping ones with uncommitted or unpushed work — reach for [gh-reaper](https://github.com/ai-ecoverse/gh-reaper):
+>
+> ```bash
+> gh extension install ai-ecoverse/gh-reaper
+> gh reaper          # survey stale worktrees everywhere (read-only)
+> gh reaper --reap   # ...then reap the ones you've forgotten
+> ```
 
 ### Supported Commands
 


### PR DESCRIPTION
YOLO scatters isolated checkouts under `.yolo/`, and `yolo --mop` only cleans the **current** repo. After a few weeks of multi-agent sessions across many repos, those `.yolo/` worktrees pile up unnoticed.

[**gh-reaper**](https://github.com/ai-ecoverse/gh-reaper) is the new AI Ecoverse companion for exactly this: it sweeps your whole machine for stale git worktrees, shows each one's last-touched age and disk size (oldest first), and reaps the forgotten ones — read-only by default, and it safely skips anything dirty/unpushed.

This PR cross-links the two:

- Adds `gh-reaper` to the **AI Ecoverse** ecosystem list.
- Adds a tip in the **Cleanup Mode** section noting that `--mop` is per-repo, and pointing to `gh reaper` for machine-wide, age/size-aware cleanup.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)