### PR TITLE
feat: delegate -w to gemini and qwen native worktree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,18 +200,24 @@ Some agents create and manage git worktrees themselves. For these, `yolo -w`
 worktree — the tool handles creation, naming, and cleanup, so yolo's
 `-c/--clean` and `-nc/--no-clean` flags don't apply:
 
-| Agent | Native flag | Worktree location |
-|-------|-------------|-------------------|
-| `claude` | `--worktree` | `.claude/worktrees/` |
-| `grok` | `-w` / `--worktree` | managed by grok |
-| `droid` | `-w` / `--worktree` | managed by droid |
-| `gemini` | `--worktree` | managed by gemini |
-| `qwen` | `--worktree` | `<repoRoot>/.qwen/worktrees/` |
+| Agent | Native flag | Worktree location | Notes |
+|-------|-------------|-------------------|-------|
+| `claude` | `--worktree` | `.claude/worktrees/` | always |
+| `grok` | `-w` / `--worktree` | managed by grok | always |
+| `droid` | `-w` / `--worktree` | managed by droid | always |
+| `gemini` | `--worktree` | managed by gemini | only when `experimental.worktrees` is enabled in gemini's settings |
+| `qwen` | `--worktree` | `<repoRoot>/.qwen/worktrees/` | always (on versions exposing the flag) |
 
 ```bash
 yolo -w gemini "implement feature"   # gemini manages its own worktree
 yolo -w qwen "refactor the parser"   # qwen creates .qwen/worktrees/<slug>/
 ```
+
+> **Graceful fallback:** Before delegating to `gemini`/`qwen`, yolo checks that
+> the installed version actually supports `--worktree` (and, for `gemini`, that
+> `experimental.worktrees` is enabled). If not, it transparently falls back to a
+> yolo-managed `.yolo/` worktree — so `yolo -w gemini` never breaks on an older
+> build or a default configuration.
 
 > **Note:** In multi-agent mode (comma-separated agents), yolo always creates
 > its own `.yolo/` worktree per agent so it can orchestrate panes and cleanup —
@@ -253,7 +259,7 @@ Use `--mop` to clean up orphaned worktrees from interrupted sessions or when you
 | `amp` | `--dangerously-allow-all` |
 | `aider` | `--yes-always` |
 | `cursor-agent` | `--force` |
-| `gemini` | `--yolo` (+ `-i` when prompt present; `-w` delegates to gemini's native `--worktree`) |
+| `gemini` | `--yolo` (+ `-i` when prompt present; `-w` delegates to gemini's native `--worktree` when `experimental.worktrees` is enabled, else falls back to a `.yolo/` worktree) |
 | `opencode` | *(no flags)* |
 | `qwen` | `--yolo` (+ `-i` when prompt present; `-w` delegates to qwen's native `--worktree`) |
 | `kimi` | `--yolo` (+ `--command` when prompt present) |

--- a/README.md
+++ b/README.md
@@ -193,6 +193,30 @@ yolo -w -nc claude "keep this work"
    - With `-nc/--no-clean`: Preserves worktree without prompting
    - Without flags: Prompts user whether to clean up
 
+#### Native Worktree Delegation
+
+Some agents create and manage git worktrees themselves. For these, `yolo -w`
+**delegates** to the tool's own worktree support instead of creating a `.yolo/`
+worktree — the tool handles creation, naming, and cleanup, so yolo's
+`-c/--clean` and `-nc/--no-clean` flags don't apply:
+
+| Agent | Native flag | Worktree location |
+|-------|-------------|-------------------|
+| `claude` | `--worktree` | `.claude/worktrees/` |
+| `grok` | `-w` / `--worktree` | managed by grok |
+| `droid` | `-w` / `--worktree` | managed by droid |
+| `gemini` | `--worktree` | managed by gemini |
+| `qwen` | `--worktree` | `<repoRoot>/.qwen/worktrees/` |
+
+```bash
+yolo -w gemini "implement feature"   # gemini manages its own worktree
+yolo -w qwen "refactor the parser"   # qwen creates .qwen/worktrees/<slug>/
+```
+
+> **Note:** In multi-agent mode (comma-separated agents), yolo always creates
+> its own `.yolo/` worktree per agent so it can orchestrate panes and cleanup —
+> native delegation applies to single-agent runs only.
+
 ### Cleanup Mode
 
 Clean up all YOLO worktrees, branches, and processes at once:
@@ -229,9 +253,9 @@ Use `--mop` to clean up orphaned worktrees from interrupted sessions or when you
 | `amp` | `--dangerously-allow-all` |
 | `aider` | `--yes-always` |
 | `cursor-agent` | `--force` |
-| `gemini` | `--yolo` (+ `-i` when prompt present) |
+| `gemini` | `--yolo` (+ `-i` when prompt present; `-w` delegates to gemini's native `--worktree`) |
 | `opencode` | *(no flags)* |
-| `qwen` | `--yolo` (+ `-i` when prompt present) |
+| `qwen` | `--yolo` (+ `-i` when prompt present; `-w` delegates to qwen's native `--worktree`) |
 | `kimi` | `--yolo` (+ `--command` when prompt present) |
 | `crush` | `--yolo` (+ Ghostty injection when prompt present) |
 | `goose` | *(no flags - prompts passed via stdin)* |

--- a/executable_yolo
+++ b/executable_yolo
@@ -85,10 +85,11 @@ Usage: yolo [OPTIONS] [command] [args...]
 
 Options:
   -w, --worktree    Create a git worktree in .yolo/ before running command
-                    (exceptions: 'claude', 'grok', and 'droid' delegate to their
-                    built-in worktree support: claude uses .claude/worktrees/,
-                    grok uses its native -w/--worktree mode, droid uses its
-                    native -w/--worktree mode)
+                    (exceptions: 'claude', 'grok', 'droid', 'gemini', and 'qwen'
+                    delegate to their built-in worktree support: claude uses
+                    .claude/worktrees/, grok and droid use their native
+                    -w/--worktree mode, gemini and qwen use their native
+                    --worktree mode (qwen under .qwen/worktrees/))
   -c, --clean       Automatically clean up worktree after command completes
   -nc, --no-clean   Preserve worktree after command completes (no prompt)
   -e, --editor      Launch \$EDITOR to compose prompt (works in all modes)
@@ -106,8 +107,10 @@ Supported Commands:
   droid             No extra flags added (prompt allowed positionally)
   amp               Adds --dangerously-allow-all
   cursor-agent      Adds --force
-  gemini            Uses --yolo; adds -i when prompt present
-  qwen              Uses --yolo; adds -i when prompt present
+  gemini            Uses --yolo; adds -i when prompt present; -w delegates to
+                    gemini's native --worktree
+  qwen              Uses --yolo; adds -i when prompt present; -w delegates to
+                    qwen's native --worktree
   kimi              Uses --yolo (requires Ghostty for interactive prompts)
   opencode          No extra flags added
   crush             Uses --yolo (requires Ghostty for interactive prompts)
@@ -147,23 +150,28 @@ Examples:
   yolo -w -nc claude "keep this"   # Use claude's built-in --worktree (claude manages it)
   yolo -w grok "implement feature" # Use grok's native -w/--worktree (grok manages it)
   yolo -w droid "implement feature" # Use droid's native -w/--worktree (droid manages it)
+  yolo -w gemini "implement feature" # Use gemini's native --worktree (gemini manages it)
+  yolo -w qwen "implement feature" # Use qwen's native --worktree (qwen manages it)
   yolo -e codex,claude,gemini      # Compose prompt in editor, run 3 agents in parallel
   yolo copilot chat                # Run copilot chat with safety flags disabled
   yolo aider "add auth"            # Run aider with auto-approval
   yolo -w aider "implement feature" # Create worktree, run aider with prompt
 
 Worktree Mode:
-  When using -w/--worktree flag (for commands other than claude, grok, or droid):
+  When using -w/--worktree flag (for commands other than claude, grok, droid,
+  gemini, or qwen):
   - Creates .yolo/ directory in repository root
   - Creates branch: <command>-N (where N is the lowest available number)
   - Creates worktree: .yolo/<command>-N
   - Changes to worktree directory before running command
 
-  When using -w/--worktree flag with 'claude', 'grok', or 'droid':
+  When using -w/--worktree flag with 'claude', 'grok', 'droid', 'gemini', or 'qwen':
   - Delegates worktree management to the tool's native support
     - claude: uses --worktree (managed under .claude/worktrees/)
     - grok: uses -w/--worktree (managed by grok's native worktree system)
     - droid: uses -w/--worktree (managed by droid's native worktree system)
+    - gemini: uses --worktree (managed by gemini's native worktree system)
+    - qwen: uses --worktree (managed under <repoRoot>/.qwen/worktrees/)
   - The tool handles worktree creation, naming, and cleanup
   - yolo's -c/--clean and -nc/--no-clean flags are ignored in this mode
 
@@ -1592,11 +1600,12 @@ main() {
     fi
 
     # Track whether yolo is managing the worktree itself
-    # claude, grok, and droid have built-in --worktree / -w support, so we
-    # delegate to them rather than creating our own worktree under .yolo/
+    # claude, grok, droid, gemini, and qwen have built-in --worktree / -w
+    # support, so we delegate to them rather than creating our own worktree
+    # under .yolo/
     local yolo_managed_worktree=false
     if [[ "$use_worktree" == "true" ]]; then
-        if [[ "$command_name" == "claude" || "$command_name" == "grok" || "$command_name" == "droid" ]]; then
+        if [[ "$command_name" == "claude" || "$command_name" == "grok" || "$command_name" == "droid" || "$command_name" == "gemini" || "$command_name" == "qwen" ]]; then
             print_info "Delegating worktree management to $command_name's built-in worktree support"
             # These tools handle their own worktree lifecycle, so yolo's -c/-nc
             # cleanup flags do not apply in this mode.
@@ -1700,6 +1709,16 @@ main() {
                 local prompt_joined
                 prompt_joined=$(printf '%s ' "${command_args[@]}"); prompt_joined=${prompt_joined%% }
                 full_command+=("-i" "$prompt_joined")
+            fi
+            # gemini and qwen have native git worktree support; delegate to it
+            # when -w is requested rather than creating one with yolo's own logic.
+            #   gemini: --worktree [name]  (worktree under git's worktree dir)
+            #   qwen:   --worktree [slug]  (worktree under <repoRoot>/.qwen/worktrees/)
+            # The flag takes an optional name/slug; appending it bare and last
+            # (after the -i prompt) lets each tool auto-generate the name without
+            # consuming a following token as that name.
+            if [[ "$use_worktree" == "true" ]]; then
+                full_command+=("--worktree")
             fi
             ;;
         droid)

--- a/executable_yolo
+++ b/executable_yolo
@@ -89,7 +89,9 @@ Options:
                     delegate to their built-in worktree support: claude uses
                     .claude/worktrees/, grok and droid use their native
                     -w/--worktree mode, gemini and qwen use their native
-                    --worktree mode (qwen under .qwen/worktrees/))
+                    --worktree mode (qwen under .qwen/worktrees/). gemini only
+                    delegates when experimental.worktrees is enabled in its
+                    settings; otherwise yolo manages a .yolo/ worktree as usual)
   -c, --clean       Automatically clean up worktree after command completes
   -nc, --no-clean   Preserve worktree after command completes (no prompt)
   -e, --editor      Launch \$EDITOR to compose prompt (works in all modes)
@@ -108,7 +110,8 @@ Supported Commands:
   amp               Adds --dangerously-allow-all
   cursor-agent      Adds --force
   gemini            Uses --yolo; adds -i when prompt present; -w delegates to
-                    gemini's native --worktree
+                    gemini's native --worktree when experimental.worktrees is
+                    enabled (else falls back to a yolo-managed worktree)
   qwen              Uses --yolo; adds -i when prompt present; -w delegates to
                     qwen's native --worktree
   kimi              Uses --yolo (requires Ghostty for interactive prompts)
@@ -170,10 +173,14 @@ Worktree Mode:
     - claude: uses --worktree (managed under .claude/worktrees/)
     - grok: uses -w/--worktree (managed by grok's native worktree system)
     - droid: uses -w/--worktree (managed by droid's native worktree system)
-    - gemini: uses --worktree (managed by gemini's native worktree system)
+    - gemini: uses --worktree (requires experimental.worktrees enabled in
+              gemini's settings; otherwise yolo manages a .yolo/ worktree)
     - qwen: uses --worktree (managed under <repoRoot>/.qwen/worktrees/)
   - The tool handles worktree creation, naming, and cleanup
   - yolo's -c/--clean and -nc/--no-clean flags are ignored in this mode
+  - If a tool's native worktree support is unavailable (e.g. an older version
+    without the flag, or gemini without experimental.worktrees enabled), yolo
+    transparently falls back to a yolo-managed .yolo/ worktree
 
 Cleanup Mode:
   When using -m/--mop flag:
@@ -361,6 +368,61 @@ get_command_flags() {
 # Check if a command exists in PATH
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Check whether gemini's native worktree feature is actually enabled.
+# gemini gates --worktree behind `experimental.worktrees: true` in its settings
+# and exits with an error if it is not set, so we must confirm it is on before
+# delegating (otherwise we would break `yolo -w gemini`). Settings are read from
+# the workspace, the git root, and the user home; jq is used when available,
+# otherwise a conservative grep. Returns 0 only when clearly enabled.
+gemini_worktrees_enabled() {
+    local f root
+    local -a candidates=("$PWD/.gemini/settings.json")
+    root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    [[ -n "$root" && "$root" != "$PWD" ]] && candidates+=("$root/.gemini/settings.json")
+    candidates+=("$HOME/.gemini/settings.json")
+
+    for f in "${candidates[@]}"; do
+        [[ -f "$f" ]] || continue
+        if command_exists jq; then
+            if jq -e '.experimental.worktrees == true' "$f" >/dev/null 2>&1; then
+                return 0
+            fi
+        elif grep -Eq '"worktrees"[[:space:]]*:[[:space:]]*true' "$f"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Decide whether to delegate worktree creation to the agent's own native
+# support (vs. yolo creating a .yolo/ worktree). claude/grok/droid have stable,
+# always-on support. gemini/qwen gained --worktree more recently, so we probe
+# the installed binary (and gemini's experimental setting) and fall back to a
+# yolo-managed worktree when delegation would not actually work — e.g. an older
+# version without the flag, or gemini without experimental.worktrees enabled.
+agent_native_worktree_ready() {
+    local agent="$1"
+    case "$agent" in
+        claude|grok|droid)
+            return 0
+            ;;
+        qwen)
+            # qwen's --worktree works out of the box; just confirm this build
+            # actually exposes the flag.
+            "$agent" --help 2>/dev/null | grep -q -- '--worktree'
+            ;;
+        gemini)
+            # gemini exposes --worktree but only honours it when
+            # experimental.worktrees is enabled in its settings.
+            "$agent" --help 2>/dev/null | grep -q -- '--worktree' || return 1
+            gemini_worktrees_enabled
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 # Get all installed supported coding agents
@@ -1599,13 +1661,16 @@ main() {
         print_info "Will attempt to run it anyway..."
     fi
 
-    # Track whether yolo is managing the worktree itself
-    # claude, grok, droid, gemini, and qwen have built-in --worktree / -w
-    # support, so we delegate to them rather than creating our own worktree
-    # under .yolo/
+    # Track whether yolo is managing the worktree itself.
+    # claude, grok, droid, gemini, and qwen can manage their own worktree, so we
+    # delegate to them rather than creating one under .yolo/ -- but only when
+    # that native support is actually usable (see agent_native_worktree_ready).
+    # Otherwise we fall back to a yolo-managed worktree.
     local yolo_managed_worktree=false
+    local delegate_worktree=false
     if [[ "$use_worktree" == "true" ]]; then
-        if [[ "$command_name" == "claude" || "$command_name" == "grok" || "$command_name" == "droid" || "$command_name" == "gemini" || "$command_name" == "qwen" ]]; then
+        if agent_native_worktree_ready "$command_name"; then
+            delegate_worktree=true
             print_info "Delegating worktree management to $command_name's built-in worktree support"
             # These tools handle their own worktree lifecycle, so yolo's -c/-nc
             # cleanup flags do not apply in this mode.
@@ -1613,6 +1678,12 @@ main() {
                 print_warning "-c/--clean and -nc/--no-clean are ignored with '$command_name -w' ($command_name manages cleanup)"
             fi
         else
+            # gemini/qwen have a native --worktree but it isn't usable here
+            # (flag missing on this version, or gemini's experimental.worktrees
+            # is disabled), so fall back to a yolo-managed worktree.
+            if [[ "$command_name" == "gemini" || "$command_name" == "qwen" ]]; then
+                print_info "$command_name's native --worktree is unavailable here; falling back to a yolo-managed worktree"
+            fi
             if ! create_worktree "$command_name"; then
                 exit 1
             fi
@@ -1711,19 +1782,21 @@ main() {
                 full_command+=("-i" "$prompt_joined")
             fi
             # gemini and qwen have native git worktree support; delegate to it
-            # when -w is requested rather than creating one with yolo's own logic.
-            #   gemini: --worktree [name]  (worktree under git's worktree dir)
+            # when -w is requested (and delegation was deemed usable) rather than
+            # creating one with yolo's own logic.
+            #   gemini: --worktree [name]  (gemini manages the location; requires
+            #           experimental.worktrees enabled in its settings)
             #   qwen:   --worktree [slug]  (worktree under <repoRoot>/.qwen/worktrees/)
             # The flag takes an optional name/slug; appending it bare and last
             # (after the -i prompt) lets each tool auto-generate the name without
             # consuming a following token as that name.
-            if [[ "$use_worktree" == "true" ]]; then
+            if [[ "$delegate_worktree" == "true" ]]; then
                 full_command+=("--worktree")
             fi
             ;;
         droid)
             # droid has native -w/--worktree support; delegate to it when requested
-            if [[ "$use_worktree" == "true" ]]; then
+            if [[ "$delegate_worktree" == "true" ]]; then
                 full_command+=("-w")
                 # -w/--worktree takes an optional [name]; use -- to stop option
                 # parsing so the first prompt arg isn't consumed as the name.
@@ -1804,7 +1877,7 @@ main() {
                 local flag_array=($flags)
                 full_command+=("${flag_array[@]}")
             fi
-            if [[ "$use_worktree" == "true" ]]; then
+            if [[ "$delegate_worktree" == "true" ]]; then
                 full_command+=("--worktree")
                 # --worktree takes an optional [name]; use -- to stop option
                 # parsing so the first prompt arg isn't consumed as the name.
@@ -1823,7 +1896,7 @@ main() {
                 local flag_array=($flags)
                 full_command+=("${flag_array[@]}")
             fi
-            if [[ "$use_worktree" == "true" ]]; then
+            if [[ "$delegate_worktree" == "true" ]]; then
                 full_command+=("-w")
                 # -w/--worktree can take an optional name; use -- to stop parsing
                 if (( ${#command_args[@]} )); then

--- a/test.sh
+++ b/test.sh
@@ -608,6 +608,104 @@ EOF
     rm -f "$droid_cmd"
 }
 
+# Shared assertions for agents that delegate to a native --worktree and pass
+# their prompt via -i (gemini, qwen). For these, yolo appends --worktree LAST
+# (after the -i prompt) and must not create its own .yolo/ worktree.
+_assert_native_worktree_via_i() {
+    local agent="$1"
+
+    # Create a temporary git repository for testing
+    local test_repo="/tmp/yolo_test_${agent}_$$"
+    mkdir -p "$test_repo"
+    cd "$test_repo"
+
+    # Initialize git repo
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "test" > README.md
+    git add README.md
+    git commit -q -m "Initial commit"
+
+    # Create a dummy agent command that echoes args (so we can assert pass-through)
+    local agent_cmd="/tmp/$agent"
+    cat > "$agent_cmd" << 'EOF'
+#!/bin/bash
+echo "Running in: $PWD"
+echo "Args: $@"
+EOF
+    chmod +x "$agent_cmd"
+
+    # Assertion 1: --worktree is passed through when -w is set
+    run_test
+    local output
+    if output=$(PATH="/tmp:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -w "$agent" "fix the bug" 2>&1); then
+        if echo "$output" | grep -F -q -- "--worktree"; then
+            print_pass "yolo -w $agent passes through --worktree flag"
+        else
+            print_fail "yolo -w $agent should pass --worktree (got: $output)"
+        fi
+    else
+        print_fail "yolo -w $agent failed to run"
+    fi
+
+    # Assertion 2: --worktree is appended after the -i prompt (bare, last) so the
+    # tool auto-generates the worktree name instead of eating the prompt
+    run_test
+    if echo "$output" | grep -F -q -- "-i fix the bug --worktree"; then
+        print_pass "yolo -w $agent appends --worktree after the -i prompt"
+    else
+        print_fail "yolo -w $agent should append --worktree after -i prompt (got: $output)"
+    fi
+
+    # Assertion 3: yolo did NOT create a .yolo/ directory
+    run_test
+    if [[ ! -d "$test_repo/.yolo" ]]; then
+        print_pass "yolo -w $agent does not create .yolo/ worktree directory"
+    else
+        print_fail "yolo -w $agent should not create .yolo/ directory"
+    fi
+
+    # Assertion 4: yolo did NOT create a git worktree
+    run_test
+    local wt_count
+    wt_count=$(git worktree list | wc -l | tr -d ' ')
+    if [[ "$wt_count" == "1" ]]; then
+        print_pass "yolo -w $agent does not invoke git worktree add"
+    else
+        print_fail "yolo -w $agent should not create a git worktree (found $wt_count)"
+    fi
+
+    # Assertion 5: yolo <agent> (without -w) does NOT pass --worktree
+    run_test
+    if output=$(PATH="/tmp:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" "$agent" "hello" 2>&1); then
+        if ! echo "$output" | grep -F -q -- "--worktree"; then
+            print_pass "yolo $agent (no -w) does not pass --worktree"
+        else
+            print_fail "yolo $agent should not pass --worktree without -w (got: $output)"
+        fi
+    else
+        print_fail "yolo $agent failed to run"
+    fi
+
+    # Cleanup
+    cd /tmp
+    rm -rf "$test_repo"
+    rm -f "$agent_cmd"
+}
+
+# Test 11: Test yolo -w gemini delegates to gemini's native --worktree
+test_gemini_builtin_worktree() {
+    print_test_header "Test 11: Gemini Built-in Worktree Delegation"
+    _assert_native_worktree_via_i "gemini"
+}
+
+# Test 12: Test yolo -w qwen delegates to qwen's native --worktree
+test_qwen_builtin_worktree() {
+    print_test_header "Test 12: Qwen Built-in Worktree Delegation"
+    _assert_native_worktree_via_i "qwen"
+}
+
 # Print summary
 print_summary() {
     echo ""
@@ -651,6 +749,8 @@ main() {
     test_argument_preservation
     test_claude_builtin_worktree
     test_droid_builtin_worktree
+    test_gemini_builtin_worktree
+    test_qwen_builtin_worktree
 
     print_summary
 }

--- a/test.sh
+++ b/test.sh
@@ -611,6 +611,11 @@ EOF
 # Shared assertions for agents that delegate to a native --worktree and pass
 # their prompt via -i (gemini, qwen). For these, yolo appends --worktree LAST
 # (after the -i prompt) and must not create its own .yolo/ worktree.
+#
+# yolo probes "<agent> --help" for the flag before delegating, and for gemini it
+# also requires experimental.worktrees enabled in settings, so the dummy agent
+# advertises --worktree on --help and the gemini case writes an enabling
+# workspace settings file.
 _assert_native_worktree_via_i() {
     local agent="$1"
 
@@ -627,14 +632,26 @@ _assert_native_worktree_via_i() {
     git add README.md
     git commit -q -m "Initial commit"
 
-    # Create a dummy agent command that echoes args (so we can assert pass-through)
+    # Create a dummy agent command. On --help it advertises --worktree (so yolo's
+    # capability probe succeeds); otherwise it echoes its args for assertions.
     local agent_cmd="/tmp/$agent"
     cat > "$agent_cmd" << 'EOF'
 #!/bin/bash
+if [ "$1" = "--help" ]; then
+  echo "  -w, --worktree   Start in a new git worktree  [string]"
+  exit 0
+fi
 echo "Running in: $PWD"
 echo "Args: $@"
 EOF
     chmod +x "$agent_cmd"
+
+    # gemini only honours --worktree when experimental.worktrees is enabled;
+    # enable it in a workspace settings file so the delegation path is taken.
+    if [[ "$agent" == "gemini" ]]; then
+        mkdir -p .gemini
+        printf '%s\n' '{"experimental": {"worktrees": true}}' > .gemini/settings.json
+    fi
 
     # Assertion 1: --worktree is passed through when -w is set
     run_test
@@ -706,6 +723,76 @@ test_qwen_builtin_worktree() {
     _assert_native_worktree_via_i "qwen"
 }
 
+# Test 13: When gemini's native worktree support is NOT usable (experimental
+# .worktrees disabled), yolo must fall back to a yolo-managed .yolo/ worktree
+# instead of passing --worktree (which gemini would reject).
+test_gemini_worktree_fallback() {
+    print_test_header "Test 13: Gemini Worktree Fallback (experimental disabled)"
+
+    # Clean HOME so no user-level .gemini/settings.json can enable worktrees
+    local clean_home="/tmp/yolo_test_gemini_home_$$"
+    mkdir -p "$clean_home"
+
+    local test_repo="/tmp/yolo_test_gemini_fb_$$"
+    mkdir -p "$test_repo"
+    cd "$test_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "test" > README.md
+    git add README.md
+    git commit -q -m "Initial commit"
+
+    # Dummy gemini advertises --worktree on --help, but no settings enable it
+    local agent_cmd="/tmp/gemini"
+    cat > "$agent_cmd" << 'EOF'
+#!/bin/bash
+if [ "$1" = "--help" ]; then
+  echo "  -w, --worktree   Start in a new git worktree  [string]"
+  exit 0
+fi
+echo "Running in: $PWD"
+echo "Args: $@"
+EOF
+    chmod +x "$agent_cmd"
+
+    # Use -nc so the fallback worktree is preserved without an interactive prompt
+    local output
+    output=$(HOME="$clean_home" PATH="/tmp:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -w -nc gemini "fix the bug" 2>&1)
+
+    # Assertion 1: yolo announces the fallback
+    run_test
+    if echo "$output" | grep -F -q -- "falling back to a yolo-managed worktree"; then
+        print_pass "yolo -w gemini falls back when experimental.worktrees is disabled"
+    else
+        print_fail "yolo -w gemini should fall back when experimental disabled (got: $output)"
+    fi
+
+    # Assertion 2: yolo created its own .yolo/ worktree
+    run_test
+    if [[ -d "$test_repo/.yolo" ]]; then
+        print_pass "yolo -w gemini (disabled) creates a yolo-managed .yolo/ worktree"
+    else
+        print_fail "yolo -w gemini (disabled) should create a .yolo/ fallback (got: $output)"
+    fi
+
+    # Assertion 3: --worktree is NOT passed to gemini in the fallback path.
+    # (Scope the check to the dummy's "Args:" line so the fallback info message,
+    # which mentions "--worktree", doesn't trigger a false positive.)
+    run_test
+    if ! echo "$output" | grep -E -q -- "Args:.*--worktree"; then
+        print_pass "yolo -w gemini (disabled) does not pass --worktree to gemini"
+    else
+        print_fail "yolo -w gemini (disabled) should not pass --worktree (got: $output)"
+    fi
+
+    # Cleanup (the .yolo/ worktree lives inside test_repo, so this removes it too)
+    cd /tmp
+    git -C "$test_repo" worktree prune 2>/dev/null || true
+    rm -rf "$test_repo" "$clean_home"
+    rm -f "$agent_cmd"
+}
+
 # Print summary
 print_summary() {
     echo ""
@@ -751,6 +838,7 @@ main() {
     test_droid_builtin_worktree
     test_gemini_builtin_worktree
     test_qwen_builtin_worktree
+    test_gemini_worktree_fallback
 
     print_summary
 }


### PR DESCRIPTION
## What

The **Gemini CLI** (≥ 0.45) and **Qwen Code** (≥ 0.17) have both gained a native `--worktree` flag that creates and manages an isolated git worktree for the session — exactly the capability `claude`, `grok`, and `droid` already expose and that YOLO already delegates to.

This PR teaches YOLO to delegate `-w` to gemini's and qwen's built-in worktree support instead of creating its own `.yolo/` worktree.

## How it was discovered

The agents were installed via Homebrew/npm and were several versions behind. After updating them and re-checking `--help`:

| Agent | Old → New | Native worktree flag |
|-------|-----------|----------------------|
| `gemini` (gemini-cli) | 0.21.3 → 0.45.2 | `-w, --worktree` — *"Start Gemini in a new git worktree. If no name is provided, one is generated automatically."* |
| `qwen` (@qwen-code/qwen-code) | 0.3.0 → 0.17.1 | `--worktree` — *"Start the session inside a git worktree at `<repoRoot>/.qwen/worktrees/<slug>/`… On exit, the WorktreeExitDialog prompts to keep or remove."* |

The other agents were also updated and re-checked (codex, copilot, cursor-agent, opencode, kimi, crush, goose, pi, amp, auggie) — none of them gained git-**worktree** creation (they expose `--add-dir` / `--cwd` / session `--fork` only), so they continue to use YOLO-managed `.yolo/` worktrees.

## Behavior

```bash
yolo -w gemini "implement feature"   # → gemini --yolo -i implement feature --worktree
yolo -w qwen "refactor the parser"   # → qwen --yolo -i refactor the parser --worktree
```

- The `--worktree` flag is appended **bare and last** (after the `-i` prompt) so each tool auto-generates the worktree name without consuming a following token as the name.
- As with claude/grok/droid, the tool owns the worktree lifecycle, so YOLO's `-c/--clean` and `-nc/--no-clean` are ignored in this mode.
- Single-agent runs only — multi-agent mode keeps using YOLO's own per-agent worktrees for pane/cleanup orchestration (unchanged).

## Changes

- `executable_yolo`: add `gemini`/`qwen` to the worktree-delegation exception list; append `--worktree` in the `gemini|qwen` case; update help text.
- `README.md`: new "Native Worktree Delegation" table covering all five delegating agents.
- `test.sh`: add delegation tests for gemini and qwen (10 new assertions, mirroring the claude/droid tests).

## Testing

- `./test.sh` — the 10 new gemini/qwen assertions pass. The 3 remaining failures (aider, kimi) are **pre-existing on `main`** and unrelated to this change.
- `shellcheck executable_yolo test.sh` — `test.sh` clean; `executable_yolo` only shows two pre-existing `SC2329` *info* notices on untouched functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)