### PR TITLE
feat(worktree): auto-install dependencies in new worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Part of the **[AI Ecoverse](https://github.com/ai-ecoverse/.github)** - a compre
 - 📝 **Editor Mode**: Compose complex prompts in your preferred editor
 - 🪟 **Ghostty Support**: Native split pane support for Ghostty terminal
 - 🌳 **Worktree Isolation**: Optional `-w` flag creates isolated git worktrees
+- 📦 **Dependency Auto-install**: New worktrees get a background `npm ci`-equivalent so local checks match CI (`-wn` / `--no-install` to skip)
 - 🔒 **Safe Experimentation**: Work in isolated environments without affecting main codebase
 - 🧹 **Clean History**: Separate branches for each agent session
 - 🧽 **Mop Command**: Clean up all worktrees, branches, and processes with one command
@@ -222,6 +223,49 @@ yolo -w qwen "refactor the parser"   # qwen creates .qwen/worktrees/<slug>/
 > **Note:** In multi-agent mode (comma-separated agents), yolo always creates
 > its own `.yolo/` worktree per agent so it can orchestrate panes and cleanup —
 > native delegation applies to single-agent runs only.
+
+#### Dependency Auto-install
+
+A fresh git worktree only contains tracked files — gitignored dependencies like
+`node_modules/` are missing. That's a subtle trap for agents: local `lint`/`test`
+runs can **silently pass against stale or absent dependencies** while CI (which
+runs a clean `npm ci`) fails, sending the agent chasing phantom "version
+mismatch" bugs.
+
+To close that gap, `-w` automatically installs dependencies in the background.
+YOLO detects the package manager from the lockfile and runs the CI-equivalent,
+reproducible install:
+
+| Lockfile | Command |
+|----------|---------|
+| `package-lock.json` / `npm-shrinkwrap.json` | `npm ci` |
+| `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` |
+| `yarn.lock` | `yarn install --immutable` (or `--frozen-lockfile` on Yarn 1.x) |
+| `bun.lockb` / `bun.lock` | `bun install --frozen-lockfile` |
+
+```bash
+# Worktree + background dependency install (default)
+yolo -w claude "fix the failing test"
+
+# Skip the install (e.g. you'll install manually, or there's nothing to install)
+yolo -wn claude "tweak the docs"        # -wn = worktree, no install
+yolo -w --no-install aider "experiment"
+```
+
+Details:
+
+- **Works for both worktree styles.** For YOLO-managed `.yolo/` worktrees the
+  install starts as soon as the worktree is created. For tools with their own
+  native worktree support (`claude`, `grok`, `droid`, and `gemini`/`qwen`), YOLO
+  watches `git worktree list` and installs into the tool's worktree
+  (`.claude/worktrees/`, `.qwen/worktrees/`, etc.) once it appears.
+- **Non-blocking.** The install runs in the background so the agent starts
+  immediately. Status (`running`/`ready`/`failed`) and a log live under the
+  worktree's git dir (`<gitdir>/yolo-deps/`), keeping `git status` clean.
+- **Idempotent.** It fingerprints the lockfile and skips work that's already
+  current; an existing `node_modules` you created yourself is adopted, not wiped.
+- **Opt out** per-run with `-wn` / `--no-install`, or globally by exporting
+  `YOLO_INSTALL_DEPS=false`.
 
 ### Cleanup Mode
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ reproducible install:
 | `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` |
 | `yarn.lock` | `yarn install --immutable` (or `--frozen-lockfile` on Yarn 1.x) |
 | `bun.lockb` / `bun.lock` | `bun install --frozen-lockfile` |
+| `uv.lock` (Python) | `uv sync --frozen` |
+
+> **Python note:** uv installs into the project's `.venv`, so it only helps
+> tooling invoked through that environment (`uv run pytest`, or an activated
+> `.venv`) — unlike `node_modules`, a bare `python`/`pytest` won't pick it up.
+> That matches the normal uv workflow. Bare `requirements.txt` is intentionally
+> not auto-installed (it isn't a guaranteed-pinned lockfile).
 
 ```bash
 # Worktree + background dependency install (default)
@@ -263,7 +270,8 @@ Details:
   immediately. Status (`running`/`ready`/`failed`) and a log live under the
   worktree's git dir (`<gitdir>/yolo-deps/`), keeping `git status` clean.
 - **Idempotent.** It fingerprints the lockfile and skips work that's already
-  current; an existing `node_modules` you created yourself is adopted, not wiped.
+  current; an existing install you created yourself (`node_modules`, uv's
+  `.venv`) is adopted, not wiped.
 - **Opt out** per-run with `-wn` / `--no-install`, or globally by exporting
   `YOLO_INSTALL_DEPS=false`.
 

--- a/executable_yolo
+++ b/executable_yolo
@@ -253,6 +253,7 @@ sanitize_branch_name() {
 # Sets global variables: YOLO_BRANCH_NAME, YOLO_WORKTREE_PATH, YOLO_REPO_ROOT
 create_worktree() {
     local command_name="$1"
+    local dry_run="${2:-false}"
 
     if ! is_git_repo; then
         print_error "not in a git repository, cannot create worktree"
@@ -302,8 +303,12 @@ create_worktree() {
 
     # Kick off a CI-equivalent dependency install in the background so the agent
     # starts from a clean tree that matches CI (disable with -wn / --no-install).
-    prepare_deps "$YOLO_WORKTREE_PATH" </dev/null &
-    disown 2>/dev/null || true
+    # Skipped under --dry-run, which is preview-only (matches the native-worktree
+    # watcher, which is also guarded against dry-run).
+    if [[ "$dry_run" != "true" ]]; then
+        prepare_deps "$YOLO_WORKTREE_PATH" </dev/null &
+        disown 2>/dev/null || true
+    fi
 
     return 0
 }
@@ -318,8 +323,11 @@ detect_install_command() {
         echo "pnpm|pnpm install --frozen-lockfile"
     elif [[ -f "$dir/yarn.lock" ]]; then
         # Yarn Berry (>=2) uses --immutable; Yarn Classic (v1) --frozen-lockfile.
-        local yv
-        yv="$( (cd "$dir" 2>/dev/null && yarn --version) 2>/dev/null )"
+        # Keep the probe non-fatal: if yarn is missing the substitution exits
+        # non-zero, which under `set -e` would otherwise abort before
+        # prepare_deps reaches its "not in PATH; skipping" check.
+        local yv=""
+        yv="$( (cd "$dir" 2>/dev/null && yarn --version) 2>/dev/null )" || yv=""
         if [[ -z "$yv" || "$yv" == 1.* ]]; then
             echo "yarn|yarn install --frozen-lockfile"
         else
@@ -435,10 +443,13 @@ watch_and_prepare_deps() {
     before="$( git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' )"
 
     (
-        local waited=0 now path newpath
+        local waited=0 nap now path newpath
         while (( waited < timeout )); do
-            sleep 3
-            waited=$(( waited + 3 ))
+            # Poll every 3s, but never sleep past the timeout (keeps it a real
+            # upper bound, including small test values of YOLO_DEPS_WATCH_TIMEOUT).
+            nap=$(( timeout - waited )); (( nap > 3 )) && nap=3
+            sleep "$nap"
+            waited=$(( waited + nap ))
             # Bail out if the repo disappeared (session ended / cleanup).
             git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1 || exit 0
             now="$( git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' )"
@@ -1343,7 +1354,7 @@ run_multi_agents() {
         esac
 
         # Create dedicated worktree for each agent
-        if ! create_worktree "$agent"; then
+        if ! create_worktree "$agent" "$dry_run_flag"; then
             return 1
         fi
         # create_worktree sets globals: YOLO_WORKTREE_PATH, YOLO_BRANCH_NAME, YOLO_REPO_ROOT
@@ -1891,7 +1902,7 @@ main() {
             if [[ "$command_name" == "gemini" || "$command_name" == "qwen" ]]; then
                 print_info "$command_name's native --worktree is unavailable here; falling back to a yolo-managed worktree"
             fi
-            if ! create_worktree "$command_name"; then
+            if ! create_worktree "$command_name" "$dry_run"; then
                 exit 1
             fi
             # create_worktree sets YOLO_BRANCH_NAME, YOLO_WORKTREE_PATH, YOLO_REPO_ROOT

--- a/executable_yolo
+++ b/executable_yolo
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 
 # Color output helpers
 RED='\033[0;31m'
@@ -84,14 +84,21 @@ YOLO - AI CLI Tool Wrapper with Worktree Support
 Usage: yolo [OPTIONS] [command] [args...]
 
 Options:
-  -w, --worktree    Create a git worktree in .yolo/ before running command
+  -w, --worktree    Create a git worktree in .yolo/ before running command, then
+                    auto-install its dependencies in the background (npm ci /
+                    pnpm/yarn/bun equivalent, based on the lockfile)
                     (exceptions: 'claude', 'grok', 'droid', 'gemini', and 'qwen'
                     delegate to their built-in worktree support: claude uses
                     .claude/worktrees/, grok and droid use their native
                     -w/--worktree mode, gemini and qwen use their native
                     --worktree mode (qwen under .qwen/worktrees/). gemini only
                     delegates when experimental.worktrees is enabled in its
-                    settings; otherwise yolo manages a .yolo/ worktree as usual)
+                    settings; otherwise yolo manages a .yolo/ worktree as usual.
+                    yolo watches for the delegated worktree and installs deps
+                    there too)
+  -wn, --worktree-no-install
+                    Like -w, but skip the automatic dependency install
+  --no-install      Skip the automatic dependency install (with -w/-a)
   -c, --clean       Automatically clean up worktree after command completes
   -nc, --no-clean   Preserve worktree after command completes (no prompt)
   -e, --editor      Launch \$EDITOR to compose prompt (works in all modes)
@@ -181,6 +188,20 @@ Worktree Mode:
   - If a tool's native worktree support is unavailable (e.g. an older version
     without the flag, or gemini without experimental.worktrees enabled), yolo
     transparently falls back to a yolo-managed .yolo/ worktree
+
+Dependency Auto-install:
+  Fresh worktrees are missing gitignored dependencies (node_modules, etc.), so
+  local checks (lint, tests) can silently diverge from CI. With -w, yolo detects
+  the lockfile and runs the CI-equivalent install in the background:
+    - package-lock.json / npm-shrinkwrap.json -> npm ci
+    - pnpm-lock.yaml                           -> pnpm install --frozen-lockfile
+    - yarn.lock                                -> yarn install --immutable (or
+                                                  --frozen-lockfile on Yarn 1.x)
+    - bun.lockb / bun.lock                     -> bun install --frozen-lockfile
+  For .yolo/ worktrees the install starts immediately; for native worktrees
+  (claude/grok/droid) yolo watches the git worktree list and installs once the
+  tool's worktree appears. Status + a log live under <gitdir>/yolo-deps/.
+  Disable with -wn / --no-install, or export YOLO_INSTALL_DEPS=false.
 
 Cleanup Mode:
   When using -m/--mop flag:
@@ -278,7 +299,167 @@ create_worktree() {
     }
 
     print_success "Now in: $YOLO_WORKTREE_PATH"
+
+    # Kick off a CI-equivalent dependency install in the background so the agent
+    # starts from a clean tree that matches CI (disable with -wn / --no-install).
+    prepare_deps "$YOLO_WORKTREE_PATH" </dev/null &
+    disown 2>/dev/null || true
+
     return 0
+}
+
+# Detect the CI-equivalent dependency-install command for a project directory,
+# based on which lockfile is present. Echoes "<manager>|<command>" or nothing
+# when no recognized lockfile exists.
+detect_install_command() {
+    local dir="$1"
+
+    if [[ -f "$dir/pnpm-lock.yaml" ]]; then
+        echo "pnpm|pnpm install --frozen-lockfile"
+    elif [[ -f "$dir/yarn.lock" ]]; then
+        # Yarn Berry (>=2) uses --immutable; Yarn Classic (v1) --frozen-lockfile.
+        local yv
+        yv="$( (cd "$dir" 2>/dev/null && yarn --version) 2>/dev/null )"
+        if [[ -z "$yv" || "$yv" == 1.* ]]; then
+            echo "yarn|yarn install --frozen-lockfile"
+        else
+            echo "yarn|yarn install --immutable"
+        fi
+    elif [[ -f "$dir/bun.lockb" || -f "$dir/bun.lock" ]]; then
+        echo "bun|bun install --frozen-lockfile"
+    elif [[ -f "$dir/package-lock.json" || -f "$dir/npm-shrinkwrap.json" ]]; then
+        echo "npm|npm ci"
+    fi
+    # Extension point: Cargo.lock, uv.lock/poetry.lock, Gemfile.lock, go.sum,
+    # composer.lock -- add cases above as the need arises.
+}
+
+# Compute a cheap fingerprint of a directory's lockfiles so we can tell when an
+# install is already current and skip redundant work.
+deps_fingerprint() {
+    local dir="$1" f acc=""
+    for f in pnpm-lock.yaml yarn.lock bun.lockb bun.lock package-lock.json npm-shrinkwrap.json; do
+        [[ -f "$dir/$f" ]] && acc="$acc $(cksum < "$dir/$f" 2>/dev/null)"
+    done
+    printf '%s' "$acc" | cksum | awk '{print $1"-"$2}'
+}
+
+# Install a worktree's dependencies in the background using the CI-equivalent
+# command for its package manager. Idempotent: no-ops when deps are already
+# current. Writes status ("running"/"ready"/"failed") and a log under the
+# worktree's git dir so the working tree (and `git status`) stay clean.
+# Disabled by -wn / --no-install (YOLO_INSTALL_DEPS=false).
+prepare_deps() {
+    local dir="$1"
+    [[ -z "$dir" ]] && dir="$PWD"
+
+    # Opt-out (set by -wn / --no-install, or exported by the user).
+    case "${YOLO_INSTALL_DEPS:-true}" in
+        false|0|no|off) return 0 ;;
+    esac
+
+    local spec manager cmd
+    spec="$(detect_install_command "$dir")"
+    [[ -z "$spec" ]] && return 0
+    manager="${spec%%|*}"
+    cmd="${spec#*|}"
+
+    if ! command_exists "$manager"; then
+        print_warning "deps: '$manager' not in PATH; skipping auto-install in $(basename "$dir")"
+        return 0
+    fi
+
+    local gitdir state_dir
+    gitdir="$( (cd "$dir" 2>/dev/null && git rev-parse --absolute-git-dir) 2>/dev/null )"
+    if [[ -n "$gitdir" ]]; then
+        state_dir="$gitdir/yolo-deps"
+    else
+        state_dir="$dir/.yolo-deps"
+    fi
+    mkdir -p "$state_dir" 2>/dev/null || true
+    local status_file="$state_dir/status"
+    local stamp_file="$state_dir/fingerprint"
+    local log_file="$state_dir/install.log"
+
+    local fp prev_status prev_fp
+    fp="$(deps_fingerprint "$dir")"
+    prev_status="$(cat "$status_file" 2>/dev/null || true)"
+    prev_fp="$(cat "$stamp_file" 2>/dev/null || true)"
+
+    if [[ "${YOLO_INSTALL_DEPS:-true}" != "always" ]]; then
+        # Already installed (or installing) for this exact lockfile state.
+        if [[ "$prev_fp" == "$fp" && ( "$prev_status" == "ready" || "$prev_status" == "running" ) ]]; then
+            return 0
+        fi
+        # An existing node_modules we did not create: adopt it rather than
+        # wiping it, unless the lockfile has changed since.
+        if [[ -d "$dir/node_modules" && -z "$prev_fp" ]]; then
+            echo "ready" > "$status_file"
+            echo "$fp" > "$stamp_file"
+            return 0
+        fi
+    fi
+
+    echo "running" > "$status_file"
+    echo "$fp" > "$stamp_file"
+
+    print_info "deps: installing ($manager) -- '$cmd' (log: $log_file)"
+
+    # Run the install to completion. Callers decide whether to background this
+    # (create_worktree backgrounds it; the native-worktree watcher runs it
+    # synchronously so the watcher stays alive until the install finishes).
+    local -a cmd_arr
+    read -ra cmd_arr <<< "$cmd"
+    {
+        echo "# yolo: $cmd"
+        echo "# dir:  $dir"
+    } > "$log_file"
+    if ( cd "$dir" && "${cmd_arr[@]}" ) >> "$log_file" 2>&1 </dev/null; then
+        echo "ready" > "$status_file"
+    else
+        echo "failed" > "$status_file"
+    fi
+}
+
+# Watch a repository for a NEW git worktree (one created by an agent's own
+# --worktree support, e.g. claude's .claude/worktrees/ or qwen's .qwen/
+# worktrees/) and run prepare_deps inside it. Runs detached and self-terminates
+# once it finds the worktree or hits the timeout. yolo does not own these
+# worktrees, so watching `git worktree list` is the location-agnostic way to
+# find them regardless of each tool's directory convention.
+watch_and_prepare_deps() {
+    local repo_root="$1"
+    local timeout="${2:-${YOLO_DEPS_WATCH_TIMEOUT:-120}}"
+
+    local before
+    before="$( git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' )"
+
+    (
+        local waited=0 now path newpath
+        while (( waited < timeout )); do
+            sleep 3
+            waited=$(( waited + 3 ))
+            # Bail out if the repo disappeared (session ended / cleanup).
+            git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+            now="$( git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' )"
+            newpath=""
+            while IFS= read -r path; do
+                [[ -z "$path" ]] && continue
+                if ! grep -Fxq -- "$path" <<< "$before"; then
+                    newpath="$path"
+                    break
+                fi
+            done <<< "$now"
+            if [[ -n "$newpath" ]]; then
+                # Install synchronously (outside the read loop) so this watcher
+                # stays alive until the install finishes; its parent agent
+                # session outlives it.
+                prepare_deps "$newpath"
+                exit 0
+            fi
+        done
+    ) </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null || true
 }
 
 # Get the appropriate flags for a command
@@ -1530,6 +1711,15 @@ main() {
                 auto_clean="no"
                 shift
                 ;;
+            -wn|--worktree-no-install)
+                use_worktree=true
+                YOLO_INSTALL_DEPS=false
+                shift
+                ;;
+            --no-install)
+                YOLO_INSTALL_DEPS=false
+                shift
+                ;;
             -e|--editor)
                 use_editor=true
                 shift
@@ -1676,6 +1866,23 @@ main() {
             # cleanup flags do not apply in this mode.
             if [[ -n "$auto_clean" ]]; then
                 print_warning "-c/--clean and -nc/--no-clean are ignored with '$command_name -w' ($command_name manages cleanup)"
+            fi
+            # yolo does not own the worktree the tool is about to create, so we
+            # cannot run prepare_deps directly. Instead, watch the repo for the
+            # new worktree to appear and install dependencies there in the
+            # background. Skipped in dry-run and when -wn / --no-install is set.
+            if [[ "$dry_run" != "true" ]]; then
+                case "${YOLO_INSTALL_DEPS:-true}" in
+                    false|0|no|off) : ;;
+                    *)
+                        local _deps_repo_root
+                        _deps_repo_root="$(get_repo_root)"
+                        if [[ -n "$_deps_repo_root" ]]; then
+                            print_info "deps: will auto-install in $command_name's new worktree once it appears (disable with -wn / --no-install)"
+                            watch_and_prepare_deps "$_deps_repo_root"
+                        fi
+                        ;;
+                esac
             fi
         else
             # gemini/qwen have a native --worktree but it isn't usable here

--- a/executable_yolo
+++ b/executable_yolo
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-VERSION="1.2.0"
+VERSION="1.3.0"
 
 # Color output helpers
 RED='\033[0;31m'
@@ -198,6 +198,7 @@ Dependency Auto-install:
     - yarn.lock                                -> yarn install --immutable (or
                                                   --frozen-lockfile on Yarn 1.x)
     - bun.lockb / bun.lock                     -> bun install --frozen-lockfile
+    - uv.lock (Python)                         -> uv sync --frozen
   For .yolo/ worktrees the install starts immediately; for native worktrees
   (claude/grok/droid) yolo watches the git worktree list and installs once the
   tool's worktree appears. Status + a log live under <gitdir>/yolo-deps/.
@@ -337,16 +338,21 @@ detect_install_command() {
         echo "bun|bun install --frozen-lockfile"
     elif [[ -f "$dir/package-lock.json" || -f "$dir/npm-shrinkwrap.json" ]]; then
         echo "npm|npm ci"
+    elif [[ -f "$dir/uv.lock" ]]; then
+        # uv (Python): install exactly what's locked into the project's .venv
+        # without re-resolving or mutating uv.lock -- the closest analog to
+        # `npm ci`. Only helps tooling invoked via `uv run` / the .venv.
+        echo "uv|uv sync --frozen"
     fi
-    # Extension point: Cargo.lock, uv.lock/poetry.lock, Gemfile.lock, go.sum,
-    # composer.lock -- add cases above as the need arises.
+    # Extension point: poetry.lock/pdm.lock/Pipfile.lock, Cargo.lock,
+    # Gemfile.lock, go.sum, composer.lock -- add cases above as the need arises.
 }
 
 # Compute a cheap fingerprint of a directory's lockfiles so we can tell when an
 # install is already current and skip redundant work.
 deps_fingerprint() {
     local dir="$1" f acc=""
-    for f in pnpm-lock.yaml yarn.lock bun.lockb bun.lock package-lock.json npm-shrinkwrap.json; do
+    for f in pnpm-lock.yaml yarn.lock bun.lockb bun.lock package-lock.json npm-shrinkwrap.json uv.lock; do
         [[ -f "$dir/$f" ]] && acc="$acc $(cksum < "$dir/$f" 2>/dev/null)"
     done
     printf '%s' "$acc" | cksum | awk '{print $1"-"$2}'
@@ -399,9 +405,11 @@ prepare_deps() {
         if [[ "$prev_fp" == "$fp" && ( "$prev_status" == "ready" || "$prev_status" == "running" ) ]]; then
             return 0
         fi
-        # An existing node_modules we did not create: adopt it rather than
-        # wiping it, unless the lockfile has changed since.
-        if [[ -d "$dir/node_modules" && -z "$prev_fp" ]]; then
+        # An existing install we did not create (JS node_modules, or uv's .venv):
+        # adopt it rather than wiping it, unless the lockfile has changed since.
+        local artifact_dir="node_modules"
+        [[ "$manager" == "uv" ]] && artifact_dir=".venv"
+        if [[ -d "$dir/$artifact_dir" && -z "$prev_fp" ]]; then
             echo "ready" > "$status_file"
             echo "$fp" > "$stamp_file"
             return 0

--- a/test.sh
+++ b/test.sh
@@ -793,6 +793,108 @@ EOF
     rm -f "$agent_cmd"
 }
 
+# Test 14: Dependency auto-install (-w installs, -wn / --no-install opt out)
+test_dependency_auto_install() {
+    print_test_header "Test 14: Dependency Auto-install"
+
+    # --- Flag parsing / delegation note (deterministic, no background needed) ---
+    local test_repo="/tmp/yolo_test_deps_$$"
+    mkdir -p "$test_repo"; cd "$test_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo '{"name":"x"}' > package.json
+    echo '{"lockfileVersion":3}' > package-lock.json
+    git add package.json
+    git add package-lock.json
+    git commit -q -m "init"
+
+    # Dummy claude/npm so nothing real runs; keep the watcher short-lived.
+    local bin="/tmp/yolo_test_deps_bin_$$"; mkdir -p "$bin"
+    cat > "$bin/claude" << 'EOF'
+#!/bin/bash
+echo "Args: $@"
+EOF
+    cat > "$bin/npm" << 'EOF'
+#!/bin/bash
+[[ "$1" == "ci" ]] && { mkdir -p node_modules; exit 0; }
+exit 0
+EOF
+    cat > "$bin/faketool" << 'EOF'
+#!/bin/bash
+echo "faketool ran"
+EOF
+    chmod +x "$bin/claude" "$bin/npm" "$bin/faketool"
+    # Keep the native-worktree watcher short-lived during the test.
+    export YOLO_DEPS_WATCH_TIMEOUT="${YOLO_DEPS_WATCH_TIMEOUT:-4}"
+
+    # Assertion 1: -w claude prints the watcher auto-install note
+    run_test
+    local out
+    out=$(PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -w claude "go" 2>&1 || true)
+    if echo "$out" | grep -F -q "will auto-install"; then
+        print_pass "yolo -w claude announces background dependency install"
+    else
+        print_fail "yolo -w claude should announce auto-install (got: $out)"
+    fi
+
+    # Assertion 2: -wn claude still delegates (--worktree) but skips auto-install
+    run_test
+    out=$(PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -wn claude "go" 2>&1 || true)
+    if echo "$out" | grep -F -q -- "--worktree" && ! echo "$out" | grep -F -q "will auto-install"; then
+        print_pass "yolo -wn claude delegates worktree but skips auto-install"
+    else
+        print_fail "yolo -wn claude should pass --worktree and skip auto-install (got: $out)"
+    fi
+
+    # Assertion 3: --no-install is accepted and suppresses the note
+    run_test
+    out=$(PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --no-install -w claude "go" 2>&1 || true)
+    if ! echo "$out" | grep -F -q "unknown option" && ! echo "$out" | grep -F -q "will auto-install"; then
+        print_pass "yolo --no-install -w claude is accepted and skips auto-install"
+    else
+        print_fail "yolo --no-install should be accepted and skip auto-install (got: $out)"
+    fi
+
+    # --- End-to-end install into a yolo-managed .yolo/ worktree ---
+    # Assertion 4: -w faketool installs deps (status ready + node_modules)
+    run_test
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -nc -w faketool "go" >/dev/null 2>&1 || true
+    local wt="$test_repo/.yolo/faketool-1"
+    local state=""
+    [[ -d "$wt" ]] && state="$(cd "$wt" && git rev-parse --absolute-git-dir 2>/dev/null)/yolo-deps"
+    local s=""
+    for _ in $(seq 1 40); do
+        s="$([[ -n "$state" ]] && cat "$state/status" 2>/dev/null || echo "")"
+        [[ "$s" == "ready" || "$s" == "failed" ]] && break
+        sleep 0.3
+    done
+    if [[ "$s" == "ready" && -d "$wt/node_modules" ]]; then
+        print_pass "yolo -w faketool installs deps in background (status ready, node_modules present)"
+    else
+        print_fail "yolo -w faketool should install deps (status=$s, node_modules=$([[ -d "$wt/node_modules" ]] && echo present || echo missing))"
+    fi
+
+    # Assertion 5: -wn faketool skips the install entirely
+    run_test
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -nc -wn faketool "go" >/dev/null 2>&1 || true
+    local wt2="$test_repo/.yolo/faketool-2"
+    sleep 1
+    local gd2=""
+    [[ -d "$wt2" ]] && gd2="$(cd "$wt2" && git rev-parse --absolute-git-dir 2>/dev/null)"
+    if [[ ! -d "$wt2/node_modules" && ( -z "$gd2" || ! -e "$gd2/yolo-deps/status" ) ]]; then
+        print_pass "yolo -wn faketool skips dependency install"
+    else
+        print_fail "yolo -wn faketool should not install deps (node_modules=$([[ -d "$wt2/node_modules" ]] && echo present || echo missing))"
+    fi
+
+    # Cleanup (mop removes the .yolo/ worktrees this test created)
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
+    unset YOLO_DEPS_WATCH_TIMEOUT
+    cd /tmp
+    rm -rf "$test_repo" "$bin"
+}
+
 # Print summary
 print_summary() {
     echo ""
@@ -839,6 +941,7 @@ main() {
     test_gemini_builtin_worktree
     test_qwen_builtin_worktree
     test_gemini_worktree_fallback
+    test_dependency_auto_install
 
     print_summary
 }

--- a/test.sh
+++ b/test.sh
@@ -888,11 +888,56 @@ EOF
         print_fail "yolo -wn faketool should not install deps (node_modules=$([[ -d "$wt2/node_modules" ]] && echo present || echo missing))"
     fi
 
+    # Assertion 6: --dry-run is preview-only -- it must NOT run the install
+    # (regression test: create_worktree used to install before the dry-run check).
+    # Uses a dedicated repo so node_modules can only appear if dry-run wrongly ran.
+    run_test
+    local dr_repo="/tmp/yolo_test_deps_dr_$$"
+    mkdir -p "$dr_repo"; cd "$dr_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo '{}' > package.json
+    echo '{"lockfileVersion":3}' > package-lock.json
+    git add package.json
+    git add package-lock.json
+    git commit -q -m "init"
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -n -w faketool "go" >/dev/null 2>&1 || true
+    sleep 1
+    if ! find "$dr_repo/.yolo" -name node_modules -type d 2>/dev/null | grep -q .; then
+        print_pass "yolo -n -w (dry-run) does not run the dependency install"
+    else
+        print_fail "yolo -n -w should not install deps in dry-run"
+    fi
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
+
+    # Assertion 7: yarn.lock present but yarn not installed must not abort under
+    # set -e (regression: the yarn --version probe was fatal). Run with a minimal
+    # PATH (plus our fake faketool) so any real yarn is hidden.
+    run_test
+    local yarn_repo="/tmp/yolo_test_deps_yarn_$$"
+    mkdir -p "$yarn_repo"; cd "$yarn_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo '{}' > package.json
+    : > yarn.lock
+    git add package.json
+    git add yarn.lock
+    git commit -q -m "init"
+    if PATH="$bin:/usr/bin:/bin" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -nc -w faketool "go" >/dev/null 2>&1; then
+        print_pass "yolo -w with yarn.lock but no yarn exits cleanly (no set -e abort)"
+    else
+        print_fail "yolo -w with yarn.lock but no yarn should not abort"
+    fi
+    PATH="$bin:/usr/bin:/bin" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
+
     # Cleanup (mop removes the .yolo/ worktrees this test created)
+    cd "$test_repo"
     PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
     unset YOLO_DEPS_WATCH_TIMEOUT
     cd /tmp
-    rm -rf "$test_repo" "$bin"
+    rm -rf "$test_repo" "$dr_repo" "$yarn_repo" "$bin"
 }
 
 # Print summary

--- a/test.sh
+++ b/test.sh
@@ -932,12 +932,47 @@ EOF
     fi
     PATH="$bin:/usr/bin:/bin" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
 
+    # Assertion 8: uv.lock (Python) -> background `uv sync --frozen` into .venv
+    run_test
+    cat > "$bin/uv" << 'EOF'
+#!/bin/bash
+[[ "$1" == "sync" ]] && { mkdir -p .venv; echo "uv $*"; exit 0; }
+exit 0
+EOF
+    chmod +x "$bin/uv"
+    local uv_repo="/tmp/yolo_test_deps_uv_$$"
+    mkdir -p "$uv_repo"; cd "$uv_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    printf '[project]\nname = "x"\nversion = "0.0.0"\n' > pyproject.toml
+    printf 'version = 1\n' > uv.lock
+    git add pyproject.toml
+    git add uv.lock
+    git commit -q -m "init"
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -nc -w faketool "go" >/dev/null 2>&1 || true
+    local uvwt="$uv_repo/.yolo/faketool-1"
+    local uvstate=""
+    [[ -d "$uvwt" ]] && uvstate="$(cd "$uvwt" && git rev-parse --absolute-git-dir 2>/dev/null)/yolo-deps"
+    local us=""
+    for _ in $(seq 1 40); do
+        us="$([[ -n "$uvstate" ]] && cat "$uvstate/status" 2>/dev/null || echo "")"
+        [[ "$us" == "ready" || "$us" == "failed" ]] && break
+        sleep 0.3
+    done
+    if [[ "$us" == "ready" && -d "$uvwt/.venv" ]] && grep -q "uv sync --frozen" "$uvstate/install.log" 2>/dev/null; then
+        print_pass "yolo -w (uv.lock) runs 'uv sync --frozen' into the worktree .venv"
+    else
+        print_fail "yolo -w with uv.lock should run 'uv sync --frozen' (status=$us, .venv=$([[ -d "$uvwt/.venv" ]] && echo present || echo missing))"
+    fi
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
+
     # Cleanup (mop removes the .yolo/ worktrees this test created)
     cd "$test_repo"
     PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
     unset YOLO_DEPS_WATCH_TIMEOUT
     cd /tmp
-    rm -rf "$test_repo" "$dr_repo" "$yarn_repo" "$bin"
+    rm -rf "$test_repo" "$dr_repo" "$yarn_repo" "$uv_repo" "$bin"
 }
 
 # Print summary


### PR DESCRIPTION
## What

A fresh git worktree only contains **tracked** files, so gitignored dependencies (`node_modules/`, etc.) are missing. Local `lint`/`test` then silently pass against **stale or absent** deps while CI — which runs a clean `npm ci` — fails. This sent an agent chasing a phantom biome "version mismatch" for dozens of steps before realizing its worktree was never installed.

This teaches `yolo -w` to detect the package manager from the lockfile and run the **CI-equivalent, reproducible** install in the background.

| Lockfile | Command |
|----------|---------|
| `package-lock.json` / `npm-shrinkwrap.json` | `npm ci` |
| `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` |
| `yarn.lock` | `yarn install --immutable` (or `--frozen-lockfile` on Yarn 1.x) |
| `bun.lockb` / `bun.lock` | `bun install --frozen-lockfile` |

## Works for both worktree styles

- **YOLO-managed `.yolo/` worktrees** — install starts as soon as the worktree is created (`create_worktree`).
- **Native worktrees** (`claude`, `grok`, `droid`, `gemini`, `qwen`) — yolo doesn't own those worktrees, so it watches `git worktree list` and installs into the tool's worktree (`.claude/worktrees/`, `.qwen/worktrees/`, …) once it appears. This is location-agnostic: it works regardless of each tool's directory convention, and rides on top of #39's `agent_native_worktree_ready` probe (delegation *and* fallback paths both install).

## Behavior

- **Non-blocking.** Runs in the background so the agent starts immediately. Status (`running`/`ready`/`failed`) and a log live under the worktree's git dir (`<gitdir>/yolo-deps/`), so `git status` stays clean.
- **Idempotent.** Fingerprints the lockfile and skips work that's already current; an existing `node_modules` you created yourself is adopted, not wiped.
- **Opt out** per-run with `-wn` / `--no-install`, or globally via `YOLO_INSTALL_DEPS=false`. No new flag is needed to *enable* it — it's automatic with `-w`.

## Changes

- `executable_yolo`: `detect_install_command`, `deps_fingerprint`, `prepare_deps`, `watch_and_prepare_deps`; wire into `create_worktree` and the native-delegation branch; add `-wn` / `--no-install`; help text; version `1.1.0` → `1.2.0`.
- `test.sh`: new `test_dependency_auto_install` (5 assertions — flag parsing, delegation note, end-to-end `.yolo/` install, opt-out). Honors `YOLO_DEPS_WATCH_TIMEOUT` to keep the watcher short-lived in tests.
- `README.md`: Features bullet + a "Dependency Auto-install" subsection.

## Testing

- `./test.sh` — **50 run, 0 failed** (includes the 5 new assertions; verified with Ghostty detection neutralized so the suite's osascript injection doesn't type into the active session).
- `shellcheck executable_yolo test.sh` — clean (only the two pre-existing `SC2329` info notices on untouched functions).
- Manually verified both paths end-to-end with fake `npm`/`pnpm`: `status=ready`, `node_modules` present, `git status` clean; plus pnpm detection, idempotency, and the global opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)