### PR TITLE
feat(worktree): auto-install Python deps via uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ reproducible install:
 | `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` |
 | `yarn.lock` | `yarn install --immutable` (or `--frozen-lockfile` on Yarn 1.x) |
 | `bun.lockb` / `bun.lock` | `bun install --frozen-lockfile` |
+| `uv.lock` (Python) | `uv sync --frozen` |
+
+> **Python note:** uv installs into the project's `.venv`, so it only helps
+> tooling invoked through that environment (`uv run pytest`, or an activated
+> `.venv`) — unlike `node_modules`, a bare `python`/`pytest` won't pick it up.
+> That matches the normal uv workflow. Bare `requirements.txt` is intentionally
+> not auto-installed (it isn't a guaranteed-pinned lockfile).
 
 ```bash
 # Worktree + background dependency install (default)
@@ -263,7 +270,8 @@ Details:
   immediately. Status (`running`/`ready`/`failed`) and a log live under the
   worktree's git dir (`<gitdir>/yolo-deps/`), keeping `git status` clean.
 - **Idempotent.** It fingerprints the lockfile and skips work that's already
-  current; an existing `node_modules` you created yourself is adopted, not wiped.
+  current; an existing install you created yourself (`node_modules`, uv's
+  `.venv`) is adopted, not wiped.
 - **Opt out** per-run with `-wn` / `--no-install`, or globally by exporting
   `YOLO_INSTALL_DEPS=false`.
 

--- a/executable_yolo
+++ b/executable_yolo
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-VERSION="1.2.0"
+VERSION="1.3.0"
 
 # Color output helpers
 RED='\033[0;31m'
@@ -198,6 +198,7 @@ Dependency Auto-install:
     - yarn.lock                                -> yarn install --immutable (or
                                                   --frozen-lockfile on Yarn 1.x)
     - bun.lockb / bun.lock                     -> bun install --frozen-lockfile
+    - uv.lock (Python)                         -> uv sync --frozen
   For .yolo/ worktrees the install starts immediately; for native worktrees
   (claude/grok/droid) yolo watches the git worktree list and installs once the
   tool's worktree appears. Status + a log live under <gitdir>/yolo-deps/.
@@ -337,16 +338,21 @@ detect_install_command() {
         echo "bun|bun install --frozen-lockfile"
     elif [[ -f "$dir/package-lock.json" || -f "$dir/npm-shrinkwrap.json" ]]; then
         echo "npm|npm ci"
+    elif [[ -f "$dir/uv.lock" ]]; then
+        # uv (Python): install exactly what's locked into the project's .venv
+        # without re-resolving or mutating uv.lock -- the closest analog to
+        # `npm ci`. Only helps tooling invoked via `uv run` / the .venv.
+        echo "uv|uv sync --frozen"
     fi
-    # Extension point: Cargo.lock, uv.lock/poetry.lock, Gemfile.lock, go.sum,
-    # composer.lock -- add cases above as the need arises.
+    # Extension point: poetry.lock/pdm.lock/Pipfile.lock, Cargo.lock,
+    # Gemfile.lock, go.sum, composer.lock -- add cases above as the need arises.
 }
 
 # Compute a cheap fingerprint of a directory's lockfiles so we can tell when an
 # install is already current and skip redundant work.
 deps_fingerprint() {
     local dir="$1" f acc=""
-    for f in pnpm-lock.yaml yarn.lock bun.lockb bun.lock package-lock.json npm-shrinkwrap.json; do
+    for f in pnpm-lock.yaml yarn.lock bun.lockb bun.lock package-lock.json npm-shrinkwrap.json uv.lock; do
         [[ -f "$dir/$f" ]] && acc="$acc $(cksum < "$dir/$f" 2>/dev/null)"
     done
     printf '%s' "$acc" | cksum | awk '{print $1"-"$2}'
@@ -399,9 +405,11 @@ prepare_deps() {
         if [[ "$prev_fp" == "$fp" && ( "$prev_status" == "ready" || "$prev_status" == "running" ) ]]; then
             return 0
         fi
-        # An existing node_modules we did not create: adopt it rather than
-        # wiping it, unless the lockfile has changed since.
-        if [[ -d "$dir/node_modules" && -z "$prev_fp" ]]; then
+        # An existing install we did not create (JS node_modules, or uv's .venv):
+        # adopt it rather than wiping it, unless the lockfile has changed since.
+        local artifact_dir="node_modules"
+        [[ "$manager" == "uv" ]] && artifact_dir=".venv"
+        if [[ -d "$dir/$artifact_dir" && -z "$prev_fp" ]]; then
             echo "ready" > "$status_file"
             echo "$fp" > "$stamp_file"
             return 0

--- a/test.sh
+++ b/test.sh
@@ -932,12 +932,47 @@ EOF
     fi
     PATH="$bin:/usr/bin:/bin" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
 
+    # Assertion 8: uv.lock (Python) -> background `uv sync --frozen` into .venv
+    run_test
+    cat > "$bin/uv" << 'EOF'
+#!/bin/bash
+[[ "$1" == "sync" ]] && { mkdir -p .venv; echo "uv $*"; exit 0; }
+exit 0
+EOF
+    chmod +x "$bin/uv"
+    local uv_repo="/tmp/yolo_test_deps_uv_$$"
+    mkdir -p "$uv_repo"; cd "$uv_repo"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    printf '[project]\nname = "x"\nversion = "0.0.0"\n' > pyproject.toml
+    printf 'version = 1\n' > uv.lock
+    git add pyproject.toml
+    git add uv.lock
+    git commit -q -m "init"
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" -nc -w faketool "go" >/dev/null 2>&1 || true
+    local uvwt="$uv_repo/.yolo/faketool-1"
+    local uvstate=""
+    [[ -d "$uvwt" ]] && uvstate="$(cd "$uvwt" && git rev-parse --absolute-git-dir 2>/dev/null)/yolo-deps"
+    local us=""
+    for _ in $(seq 1 40); do
+        us="$([[ -n "$uvstate" ]] && cat "$uvstate/status" 2>/dev/null || echo "")"
+        [[ "$us" == "ready" || "$us" == "failed" ]] && break
+        sleep 0.3
+    done
+    if [[ "$us" == "ready" && -d "$uvwt/.venv" ]] && grep -q "uv sync --frozen" "$uvstate/install.log" 2>/dev/null; then
+        print_pass "yolo -w (uv.lock) runs 'uv sync --frozen' into the worktree .venv"
+    else
+        print_fail "yolo -w with uv.lock should run 'uv sync --frozen' (status=$us, .venv=$([[ -d "$uvwt/.venv" ]] && echo present || echo missing))"
+    fi
+    PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
+
     # Cleanup (mop removes the .yolo/ worktrees this test created)
     cd "$test_repo"
     PATH="$bin:$PATH" run_with_timeout "$YOLO_TEST_TIMEOUT" "$YOLO_CMD" --mop >/dev/null 2>&1 || true
     unset YOLO_DEPS_WATCH_TIMEOUT
     cd /tmp
-    rm -rf "$test_repo" "$dr_repo" "$yarn_repo" "$bin"
+    rm -rf "$test_repo" "$dr_repo" "$yarn_repo" "$uv_repo" "$bin"
 }
 
 # Print summary


### PR DESCRIPTION
**Stacked on #41** (base branch is `feat/worktree-dependency-auto-install`). Review/merge #41 first, then this retargets to `main`. The diff here is just the uv delta.

## What

Extends the worktree dependency auto-install from #41 to **Python via uv**. When a fresh worktree has a `uv.lock`, yolo runs `uv sync --frozen` in the background — install exactly what's locked into the project's `.venv`, without re-resolving or mutating the lock (the closest analog to `npm ci`).

| Lockfile | Command |
|----------|---------|
| `uv.lock` | `uv sync --frozen` |

## Notes / scope

- **venv, not node_modules.** uv installs into the project's `.venv`, so this helps tooling invoked through that env (`uv run pytest`, or an activated `.venv`) — a bare `python`/`pytest` won't pick it up. That matches the normal uv workflow, so it's still a real CI-parity win for uv projects.
- The idempotent "adopt an existing install" check is generalized from `node_modules` to `.venv` for uv.
- **Bare `requirements.txt` is intentionally excluded** — it isn't a guaranteed-pinned lockfile, and a stray `pip install` could pollute global Python. poetry/pdm/pipenv can follow later if wanted (we scoped this PR to uv).

## Changes

- `executable_yolo`: `detect_install_command` gains a `uv.lock → uv sync --frozen` case; `deps_fingerprint` includes `uv.lock`; `prepare_deps` adopts `.venv` for uv; help text; version `1.2.0` → `1.3.0`.
- `test.sh`: new uv assertion in `test_dependency_auto_install` (fake `uv` creating `.venv`, repo with `uv.lock` → asserts `uv sync --frozen` ran, status `ready`, `.venv` present).
- `README.md`: uv row + a Python/venv note.

## Testing

- `./test.sh` — **51 run, 0 failed** (Ghostty detection neutralized so the suite doesn't inject keystrokes into the active session).
- `shellcheck` clean (only the pre-existing `SC2329` notices).
- Manual e2e with a fake `uv`: `status=ready`, `.venv` created, log shows `uv sync --frozen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)